### PR TITLE
Add Wyrm centipede-style game and high score support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,6 @@ Currently included:
 - Collect Dots – move the square to grab randomly spawning dots.
 - TETROID – Matrix-themed Tetris clone with falling code backdrop and
   persistent high score tracking.
+- Wyrm – Centipede-like shooter with splitting segments and rune blocks.
 
 Contributions and new mini-games are welcome!

--- a/arcade/arcade_menu.py
+++ b/arcade/arcade_menu.py
@@ -25,8 +25,8 @@ class MainMenuState(State):
         self.title_font = pygame.font.SysFont("Courier", 48, bold=True)
         self.rain_font = pygame.font.SysFont("Courier", 20)
         base_dir = os.path.join(os.path.dirname(__file__), "games")
-        self.options = []
-        for name in sorted(os.listdir(base_dir)):
+        entries = []
+        for name in os.listdir(base_dir):
             path = os.path.join(base_dir, name)
             module_file = os.path.join(path, "game.py")
             if os.path.isdir(path) and os.path.isfile(module_file):
@@ -34,7 +34,8 @@ class MainMenuState(State):
                 if display.startswith("game_"):
                     display = display[5:]
                 display = display.replace("_", " ").upper()
-                self.options.append((name, display))
+                entries.append((name, display))
+        self.options = sorted(entries, key=lambda x: x[1])
         self.options.append(("Settings", "SETTINGS"))
         self.options.append(("Quit", "QUIT"))
         self.index = 0

--- a/arcade/games/wyrm/__init__.py
+++ b/arcade/games/wyrm/__init__.py
@@ -1,0 +1,4 @@
+"""Wyrm game package exposing main()."""
+from .wyrm import WyrmGame, main
+
+__all__ = ["WyrmGame", "main"]

--- a/arcade/games/wyrm/game.py
+++ b/arcade/games/wyrm/game.py
@@ -1,0 +1,4 @@
+from .wyrm import WyrmGame
+
+class Game(WyrmGame):
+    pass

--- a/arcade/games/wyrm/meta.json
+++ b/arcade/games/wyrm/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Wyrm",
+  "author": "You",
+  "description": "Centipede-style shooter",
+  "min_version": "0.1.0"
+}

--- a/arcade/games/wyrm/tests/test_wyrm.py
+++ b/arcade/games/wyrm/tests/test_wyrm.py
@@ -1,0 +1,28 @@
+import sys
+import pathlib
+
+ARCADE_DIR = pathlib.Path(__file__).resolve().parents[3]
+sys.path.append(str(ARCADE_DIR))
+
+from games.wyrm.wyrm import WyrmGame  # type: ignore  # noqa: E402
+import high_scores  # type: ignore  # noqa: E402
+from main import load_games  # type: ignore  # noqa: E402
+
+
+def test_segment_split() -> None:
+    game = WyrmGame()
+    game.handle_segment_hit(0, 5)
+    assert len(game.wyrms) == 2
+    assert (5, 0) in game.blocks
+
+
+def test_high_score_insert(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(high_scores, "DB_PATH", str(tmp_path / "scores.db"))
+    high_scores.save_score("wyrm", "AAA", 123)
+    scores = high_scores.get_high_scores("wyrm")
+    assert ("AAA", 123) in scores
+
+
+def test_menu_registration() -> None:
+    games = load_games()
+    assert "wyrm" in games

--- a/arcade/games/wyrm/wyrm.py
+++ b/arcade/games/wyrm/wyrm.py
@@ -1,0 +1,179 @@
+import os
+from typing import List, Set, Tuple
+
+import pygame
+
+from state import State
+
+GRID_SIZE = 20
+NUM_SEGMENTS = 12
+MOVE_DELAY = 0.2
+
+
+class WyrmGame(State):
+    """Minimal Centipede-style game."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.score = 0
+        self.lives = 3
+        self.wyrms: List[List[Tuple[int, int]]] = [
+            [(i, 0) for i in range(NUM_SEGMENTS)]
+        ]
+        self.blocks: Set[Tuple[int, int]] = set()
+        self.move_timer = 0.0
+        self.direction = 1
+        self.player = [0, 0]
+        self.bullets: List[List[int]] = []
+        self.segment_img: pygame.Surface | None = None
+        self.shot_sound: pygame.mixer.Sound | None = None
+        self.grid_w = 0
+        self.grid_h = 0
+
+    def startup(self, screen: pygame.Surface) -> None:
+        super().startup(screen)
+        width, height = self.screen.get_size()
+        self.grid_w = width // GRID_SIZE
+        self.grid_h = height // GRID_SIZE
+        self.player = [self.grid_w // 2, int(self.grid_h * 0.8)]
+        base = os.path.join(os.path.dirname(__file__), "assets")
+        try:
+            self.segment_img = pygame.image.load(
+                os.path.join(base, "segment.png")
+            ).convert_alpha()
+        except Exception:
+            self.segment_img = None
+        try:
+            self.shot_sound = pygame.mixer.Sound(os.path.join(base, "shot.wav"))
+        except Exception:
+            self.shot_sound = None
+
+    def handle_keyboard(self, event: pygame.event.Event) -> None:
+        if event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_ESCAPE:
+                self.done = True
+                self.next = "menu"
+            elif event.key in (pygame.K_LEFT, pygame.K_a):
+                self.player[0] = max(0, self.player[0] - 1)
+            elif event.key in (pygame.K_RIGHT, pygame.K_d):
+                self.player[0] = min(self.grid_w - 1, self.player[0] + 1)
+            elif event.key in (pygame.K_UP, pygame.K_w):
+                min_row = int(self.grid_h * 0.8)
+                self.player[1] = max(min_row, self.player[1] - 1)
+            elif event.key in (pygame.K_DOWN, pygame.K_s):
+                self.player[1] = min(self.grid_h - 1, self.player[1] + 1)
+            elif event.key == pygame.K_SPACE:
+                self.bullets.append([self.player[0], self.player[1] - 1])
+                if self.shot_sound:
+                    self.shot_sound.play()
+
+    def update(self, dt: float) -> None:
+        self.move_timer += dt
+        if self.move_timer >= MOVE_DELAY:
+            self.move_timer = 0.0
+            self._move_wyrms()
+
+        for bullet in list(self.bullets):
+            bullet[1] -= 1
+            if bullet[1] < 0:
+                self.bullets.remove(bullet)
+                continue
+            for ci, chain in enumerate(self.wyrms):
+                for si, seg in enumerate(chain):
+                    if (bullet[0], bullet[1]) == seg:
+                        self.bullets.remove(bullet)
+                        self.handle_segment_hit(ci, si)
+                        break
+
+    def _move_wyrms(self) -> None:
+        for chain in self.wyrms:
+            head_x, head_y = chain[0]
+            new_x = head_x + self.direction
+            if (
+                new_x < 0
+                or new_x >= self.grid_w
+                or (new_x, head_y) in self.blocks
+            ):
+                self.direction *= -1
+                head_y += 1
+                new_x = head_x + self.direction
+            chain.insert(0, (new_x, head_y))
+            chain.pop()
+
+    def handle_segment_hit(self, chain_idx: int, seg_idx: int) -> None:
+        chain = self.wyrms[chain_idx]
+        hit_pos = chain[seg_idx]
+        if seg_idx == 0:
+            self.score += 100
+            del chain[0]
+            if not chain:
+                del self.wyrms[chain_idx]
+        else:
+            self.score += 10
+            left = chain[:seg_idx]
+            right = chain[seg_idx + 1 :]
+            self.blocks.add(hit_pos)
+            self.wyrms[chain_idx] = left
+            if right:
+                self.wyrms.insert(chain_idx + 1, right)
+
+    def draw(self) -> None:
+        self.screen.fill((0, 0, 0))
+        for chain in self.wyrms:
+            for x, y in chain:
+                rect = pygame.Rect(
+                    x * GRID_SIZE, y * GRID_SIZE, GRID_SIZE, GRID_SIZE
+                )
+                if self.segment_img:
+                    self.screen.blit(self.segment_img, rect)
+                else:
+                    pygame.draw.rect(self.screen, (0, 255, 0), rect)
+        for x, y in self.blocks:
+            pygame.draw.rect(
+                self.screen, (0, 155, 0), (x * GRID_SIZE, y * GRID_SIZE, GRID_SIZE, GRID_SIZE)
+            )
+        px, py = self.player
+        pygame.draw.rect(
+            self.screen,
+            (0, 255, 0),
+            (px * GRID_SIZE, py * GRID_SIZE, GRID_SIZE, GRID_SIZE),
+        )
+        for x, y in self.bullets:
+            pygame.draw.rect(
+                self.screen,
+                (0, 255, 0),
+                (x * GRID_SIZE + GRID_SIZE // 4, y * GRID_SIZE, GRID_SIZE // 2, GRID_SIZE // 2),
+            )
+        font = pygame.font.SysFont("Courier", 20)
+        text = font.render(f"Score: {self.score}", True, (0, 255, 0))
+        self.screen.blit(text, (5, 5))
+
+    def game_over(self, name: str) -> None:
+        from arcade.high_scores import save_score
+
+        save_score("wyrm", name, self.score)
+
+
+def main() -> None:
+    """Standalone entry point."""
+    pygame.init()
+    screen = pygame.display.set_mode((800, 600))
+    game = WyrmGame()
+    game.startup(screen)
+    clock = pygame.time.Clock()
+    running = True
+    while running and not game.done:
+        dt = clock.tick(60) / 1000.0
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+            else:
+                game.get_event(event)
+        game.update(dt)
+        game.draw()
+        pygame.display.flip()
+    pygame.quit()
+
+
+if __name__ == "__main__":
+    main()

--- a/arcade/high_scores.py
+++ b/arcade/high_scores.py
@@ -1,0 +1,36 @@
+import os
+import sqlite3
+from typing import List, Tuple
+
+DB_PATH = os.path.join(os.path.dirname(__file__), 'high_scores.db')
+
+
+def _get_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        'CREATE TABLE IF NOT EXISTS scores (game TEXT, name TEXT, score INTEGER)'
+    )
+    return conn
+
+
+def save_score(game: str, name: str, score: int) -> None:
+    """Save a high score entry."""
+    conn = _get_conn()
+    with conn:
+        conn.execute(
+            'INSERT INTO scores (game, name, score) VALUES (?, ?, ?)',
+            (game, name, score),
+        )
+    conn.close()
+
+
+def get_high_scores(game: str, limit: int = 5) -> List[Tuple[str, int]]:
+    """Return top *limit* scores for *game*."""
+    conn = _get_conn()
+    cur = conn.execute(
+        'SELECT name, score FROM scores WHERE game = ? ORDER BY score DESC LIMIT ?',
+        (game, limit),
+    )
+    rows = cur.fetchall()
+    conn.close()
+    return [(name, int(score)) for name, score in rows]


### PR DESCRIPTION
## Summary
- add SQLite-backed high score module
- implement Wyrm centipede-style shooter with tweakable constants
- sort menu entries alphabetically for auto-discovered games
- remove binary assets to comply with repository policies

## Testing
- `pytest arcade/games/wyrm/tests/test_wyrm.py -q`
- `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy timeout 2 python arcade/main.py`
- `pip install flake8` *(failed: Could not connect to proxy)*
- `flake8 arcade/games/wyrm/wyrm.py arcade/games/wyrm/__init__.py arcade/games/wyrm/game.py arcade/games/wyrm/tests/test_wyrm.py arcade/high_scores.py arcade/arcade_menu.py` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894b8e3599c83308efaf3966cc725ba