### PR TITLE
Improve platform install scripts and Raspberry Pi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ cd arcade
 ./install.sh   # or install.bat on Windows
 ```
 
-This will create a `venv` and generate a `run.sh` (or `run.bat`) launcher.
+This will create a `venv` and generate a `run.sh` (or `run.bat`) launcher. On
+Raspberry Pi OS the script detects the platform and reminds you to ensure SDL
+drivers are installed. A graphical desktop environment is required for Pygame.
 
 If you already have Python and SDL dependencies installed you can instead run:
 

--- a/arcade/README.md
+++ b/arcade/README.md
@@ -9,6 +9,10 @@ Simple Pygame state-driven arcade shell.
 ./install.sh
 ```
 
+The script also detects Raspberry Pi OS and will prompt you to ensure SDL
+drivers are installed. A graphical environment is required; running headless
+on a Pi will fail because Pygame needs a display.
+
 ### Windows
 ```
 install.bat

--- a/arcade/install.bat
+++ b/arcade/install.bat
@@ -1,8 +1,11 @@
 @echo off
-python -c "import sys; exit(0 if sys.version_info >= (3,9) else 1)" || (
-  echo Python 3.9 or higher is required.
+rem Verify Python version >= 3.9
+python -c "import sys; exit(0 if sys.version_info >= (3,9) else 1)" >nul 2>&1
+if errorlevel 1 (
+  echo Python 3.9^+ is required. Please install Python 3.9, 3.10, or 3.11.
   exit /b 1
 )
+
 python -m venv venv
 call venv\Scripts\activate.bat
 python -m pip install --upgrade pip

--- a/arcade/install.sh
+++ b/arcade/install.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+# Detect Raspberry Pi to provide additional guidance
+if uname -a | grep -qi "raspberry"; then
+    echo "Detected Raspberry Pi – ensure you have SDL drivers installed"
+fi
+
 if command -v apt >/dev/null 2>&1; then
     sudo apt update
     sudo apt install -y python3-venv python3-dev libsdl2-dev libsdl2-image-dev \
@@ -21,6 +26,10 @@ pip install -r requirements.txt
 
 cat > run.sh <<'EOF'
 #!/bin/sh
+if [ -z "$DISPLAY" ]; then
+    echo "A graphical display is required to run the arcade."
+    exit 1
+fi
 . "$(dirname "$0")/venv/bin/activate"
 python "$(dirname "$0")/main.py"
 EOF

--- a/arcade/run.sh
+++ b/arcade/run.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
+if [ -z "$DISPLAY" ]; then
+    echo "A graphical display is required to run the arcade."
+    exit 1
+fi
 . "$(dirname "$0")/venv/bin/activate"
 python "$(dirname "$0")/main.py"


### PR DESCRIPTION
## Summary
- Detect Raspberry Pi OS in `install.sh` and warn users to ensure SDL is installed.
- Generate launch script with a display check and clarify Raspberry Pi setup in docs.
- Require Python 3.9+ in `install.bat` and produce a clear message when too old.

## Testing
- `bash -n arcade/install.sh`
- `bash -n arcade/run.sh`
- `./arcade/run.sh` *(fails: A graphical display is required to run the arcade.)*

------
https://chatgpt.com/codex/tasks/task_e_6896c81f118083309d142124f9dc7d80