### PR TITLE
Optimize rendering and add resolution setting

### DIFF
--- a/arcade/arcade_menu.py
+++ b/arcade/arcade_menu.py
@@ -18,6 +18,7 @@ class MainMenuState(State):
         self.bg_color = (0, 0, 0)
         self.rain_glyphs = []
         self.rain_chars = string.ascii_letters + string.digits
+        self.rain_surfaces = {}
         self.phase = "game"
         self.selected_game = None
 
@@ -27,6 +28,10 @@ class MainMenuState(State):
         self.font = pygame.font.SysFont("Courier", 32)
         self.title_font = pygame.font.SysFont("Courier", 48, bold=True)
         self.rain_font = pygame.font.SysFont("Courier", 20)
+        self.rain_surfaces = {
+            ch: self.rain_font.render(ch, True, self.normal_color)
+            for ch in self.rain_chars
+        }
         base_dir = os.path.join(os.path.dirname(__file__), "games")
         entries = []
         for name in os.listdir(base_dir):
@@ -46,8 +51,9 @@ class MainMenuState(State):
         self.selected_game = None
 
         width, height = self.screen.get_size()
+        max_glyphs = 100 if width >= 800 else 50
         self.rain_glyphs = []
-        for _ in range(100):
+        for _ in range(max_glyphs):
             x = random.randrange(0, width)
             y = random.randrange(-height, 0)
             speed = random.uniform(50, 150)
@@ -141,7 +147,7 @@ class MainMenuState(State):
         width, height = self.screen.get_size()
 
         for x, y, _, char in self.rain_glyphs:
-            glyph = self.rain_font.render(char, True, self.normal_color)
+            glyph = self.rain_surfaces[char]
             self.screen.blit(glyph, (x, y))
 
         t = pygame.time.get_ticks() / 300.0

--- a/arcade/games/game_collectdots/game.py
+++ b/arcade/games/game_collectdots/game.py
@@ -30,6 +30,7 @@ class CollectDotsState(State):
                               {"highscore": 0, "plays": 0, "last_played": None})
         self.high_score = self.data.get("highscore", 0)
         self.pad_dirs = {}
+        self.overlay = pygame.Surface(self.screen.get_size(), pygame.SRCALPHA)
 
     def respawn_dot(self):
         width, height = self.screen.get_size()
@@ -200,9 +201,8 @@ class CollectDotsState(State):
             self.screen.blit(score_text, (10, 10))
 
         if self.state == "pause":
-            overlay = pygame.Surface(self.screen.get_size(), pygame.SRCALPHA)
-            overlay.fill((0, 0, 0, 200))
-            self.screen.blit(overlay, (0, 0))
+            self.overlay.fill((0, 0, 0, 200))
+            self.screen.blit(self.overlay, (0, 0))
             for i, option in enumerate(self.pause_options):
                 color = (0, 255, 0) if i == self.pause_index else (0, 155, 0)
                 prefix = "> " if i == self.pause_index else "  "

--- a/arcade/games/wyrm/wyrm.py
+++ b/arcade/games/wyrm/wyrm.py
@@ -29,6 +29,7 @@ class WyrmGame(State):
         self.shot_sound: pygame.mixer.Sound | None = None
         self.grid_w = 0
         self.grid_h = 0
+        self.font: pygame.font.Font | None = None
 
     def startup(self, screen: pygame.Surface, num_players: int = 1) -> None:
         super().startup(screen, num_players)
@@ -36,6 +37,7 @@ class WyrmGame(State):
         self.grid_w = width // GRID_SIZE
         self.grid_h = height // GRID_SIZE
         self.player = [self.grid_w // 2, int(self.grid_h * 0.8)]
+        self.font = pygame.font.SysFont("Courier", 20)
         base = os.path.join(os.path.dirname(__file__), "assets")
         try:
             self.segment_img = pygame.image.load(
@@ -177,9 +179,9 @@ class WyrmGame(State):
                 (0, 255, 0),
                 (x * GRID_SIZE + GRID_SIZE // 4, y * GRID_SIZE, GRID_SIZE // 2, GRID_SIZE // 2),
             )
-        font = pygame.font.SysFont("Courier", 20)
-        text = font.render(f"Score: {self.score}", True, (0, 255, 0))
-        self.screen.blit(text, (5, 5))
+        if self.font:
+            text = self.font.render(f"Score: {self.score}", True, (0, 255, 0))
+            self.screen.blit(text, (5, 5))
 
     def game_over(self, name: str) -> None:
         from arcade.high_scores import save_score

--- a/arcade/main.py
+++ b/arcade/main.py
@@ -87,6 +87,8 @@ def main():
         current_state.update(dt)
         current_state.draw()
         pygame.display.flip()
+        if os.environ.get("PYARCADE_DEBUG_FPS") == "1":
+            pygame.display.set_caption(f"Arcade {clock.get_fps():.1f} FPS")
 
         if current_state.quit:
             running = False
@@ -96,6 +98,7 @@ def main():
             if isinstance(current_state, SettingsState):
                 settings = load_json(SETTINGS_PATH, DEFAULT_SETTINGS)
                 pygame.mixer.music.set_volume(settings.get("sound_volume", 1.0))
+                base_size = tuple(settings.get("window_size", [800, 600]))
                 flags = pygame.SCALED | (pygame.FULLSCREEN if settings.get("fullscreen") else 0)
                 screen = pygame.display.set_mode(base_size, flags)
                 for state in states.values():

--- a/arcade/settings_state.py
+++ b/arcade/settings_state.py
@@ -8,8 +8,9 @@ DEFAULT_SETTINGS = {
     "window_size": [800, 600],
     "fullscreen": False,
     "sound_volume": 1.0,
-    "keybindings": {}
+    "keybindings": {},
 }
+RESOLUTIONS = [(640, 480), (800, 600)]
 
 
 class SettingsState(State):
@@ -18,7 +19,9 @@ class SettingsState(State):
         self.font = pygame.font.SysFont("Courier", 32)
         self.index = 0
         self.settings = load_json(SETTINGS_PATH, DEFAULT_SETTINGS)
-        self.options = ["Fullscreen", "Volume", "Back"]
+        size = tuple(self.settings.get("window_size", RESOLUTIONS[1]))
+        self.res_index = RESOLUTIONS.index(size) if size in RESOLUTIONS else 1
+        self.options = ["Fullscreen", "Resolution", "Volume", "Back"]
 
     def handle_keyboard(self, event):
         if event.type == pygame.KEYDOWN:
@@ -75,6 +78,12 @@ class SettingsState(State):
         if option == "Fullscreen":
             if delta != 0:
                 self.settings["fullscreen"] = not self.settings.get("fullscreen", False)
+        elif option == "Resolution":
+            if delta < 0:
+                self.res_index = max(0, self.res_index - 1)
+            elif delta > 0:
+                self.res_index = min(len(RESOLUTIONS) - 1, self.res_index + 1)
+            self.settings["window_size"] = list(RESOLUTIONS[self.res_index])
         elif option == "Volume":
             vol = self.settings.get("sound_volume", 1.0) + delta
             self.settings["sound_volume"] = max(0.0, min(1.0, round(vol, 2)))
@@ -88,6 +97,9 @@ class SettingsState(State):
             prefix = "> " if i == self.index else "  "
             if option == "Fullscreen":
                 value = "On" if self.settings.get("fullscreen", False) else "Off"
+            elif option == "Resolution":
+                w, h = self.settings.get("window_size", RESOLUTIONS[self.res_index])
+                value = f"{w}x{h}"
             elif option == "Volume":
                 value = f"{self.settings.get('sound_volume', 1.0):.1f}"
             else:


### PR DESCRIPTION
## Summary
- Pre-render rain glyphs and reduce count on smaller screens for smoother menus and Tetroid gameplay
- Cache surfaces and fonts to avoid per-frame allocations
- Add 640x480 resolution option and apply settings immediately, with optional FPS display

## Testing
- `python -m py_compile arcade/arcade_menu.py arcade/games/game_collectdots/game.py arcade/games/game_tetroid/game.py arcade/games/wyrm/wyrm.py arcade/main.py arcade/settings_state.py`


------
https://chatgpt.com/codex/tasks/task_e_6896cedd7ee48330852a831bf501df0e