### PR TITLE
Protect default settings object when loading JSON

### DIFF
--- a/arcade/utils/persistence.py
+++ b/arcade/utils/persistence.py
@@ -1,4 +1,5 @@
 import json
+import copy
 from pathlib import Path
 from typing import Any
 
@@ -11,9 +12,10 @@ def save_json(path: str, data: Any) -> None:
 
 
 def load_json(path: str, default: Any) -> Any:
-    """Load JSON data from *path* or return *default* if missing or invalid."""
+    """Load JSON data from *path* or return a copy of *default* if missing or invalid."""
     try:
         with open(path, "r", encoding="utf-8") as f:
             return json.load(f)
     except Exception:
-        return default
+        # Return a deep copy to avoid callers mutating the provided default object
+        return copy.deepcopy(default)


### PR DESCRIPTION
## Summary
- Avoid mutating default configuration objects by returning a deep copy when JSON load fails

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d747627c8330890329a40208f350