### PR TITLE
Add split-screen multiplayer and items to kart8

### DIFF
--- a/arcade/arcade_menu.py
+++ b/arcade/arcade_menu.py
@@ -26,6 +26,7 @@ class MainMenuState(State):
     def startup(self, screen, num_players: int = 1):
         super().startup(screen, num_players)
         self.num_players = 1
+        self.game_options = {}
         self.font = pygame.font.SysFont("Courier", 32)
         self.title_font = pygame.font.SysFont("Courier", 48, bold=True)
         self.rain_font = pygame.font.SysFont("Courier", 20)
@@ -93,14 +94,31 @@ class MainMenuState(State):
             if event.type == pygame.KEYDOWN:
                 if event.key in (pygame.K_1, pygame.K_KP1):
                     self.num_players = 1
-                    self.next = self.selected_game
-                    self.done = True
                 elif event.key in (pygame.K_2, pygame.K_KP2):
                     self.num_players = 2
+                elif event.key == pygame.K_ESCAPE:
+                    self.phase = "game"
+                    return
+                else:
+                    return
+                if self.selected_game == "kart8":
+                    self.phase = "items"
+                else:
+                    self.game_options = {}
+                    self.next = self.selected_game
+                    self.done = True
+        elif self.phase == "items":
+            if event.type == pygame.KEYDOWN:
+                if event.key in (pygame.K_y, pygame.K_1, pygame.K_KP1):
+                    self.game_options = {"items": True}
+                    self.next = self.selected_game
+                    self.done = True
+                elif event.key in (pygame.K_n, pygame.K_2, pygame.K_KP2):
+                    self.game_options = {"items": False}
                     self.next = self.selected_game
                     self.done = True
                 elif event.key == pygame.K_ESCAPE:
-                    self.phase = "game"
+                    self.phase = "players"
 
     def handle_gamepad(self, event):
         if self.phase == "game":
@@ -133,14 +151,31 @@ class MainMenuState(State):
             if event.type == pygame.JOYBUTTONDOWN:
                 if event.button == 0:
                     self.num_players = 1
+                elif event.button == 1:
+                    self.num_players = 2
+                elif event.button in (7, 9):
+                    self.phase = "game"
+                    return
+                else:
+                    return
+                if self.selected_game == "kart8":
+                    self.phase = "items"
+                else:
+                    self.game_options = {}
+                    self.next = self.selected_game
+                    self.done = True
+        elif self.phase == "items":
+            if event.type == pygame.JOYBUTTONDOWN:
+                if event.button == 0:
+                    self.game_options = {"items": True}
                     self.next = self.selected_game
                     self.done = True
                 elif event.button == 1:
-                    self.num_players = 2
+                    self.game_options = {"items": False}
                     self.next = self.selected_game
                     self.done = True
                 elif event.button in (7, 9):
-                    self.phase = "game"
+                    self.phase = "players"
 
     def update(self, dt):
         width, height = self.screen.get_size()
@@ -176,7 +211,11 @@ class MainMenuState(State):
                 text = self.font.render(prefix + label, True, color)
                 rect = text.get_rect(center=(width // 2, height // 3 + i * 40))
                 self.screen.blit(text, rect)
-        else:
+        elif self.phase == "players":
             prompt = self.font.render("1 or 2 PLAYERS?", True, self.highlight_color)
+            rect = prompt.get_rect(center=(width // 2, height // 2))
+            self.screen.blit(prompt, rect)
+        else:
+            prompt = self.font.render("ITEMS ON? Y/N", True, self.highlight_color)
             rect = prompt.get_rect(center=(width // 2, height // 2))
             self.screen.blit(prompt, rect)

--- a/arcade/games/kart8/engine/physics.py
+++ b/arcade/games/kart8/engine/physics.py
@@ -8,6 +8,7 @@ class Car:
     x: float = 0.0  # lateral position (-1..1 roughly)
     speed: float = 0.0
     color: tuple = (0, 0, 255)
+    oil_timer: float = 0.0
 
     max_speed: float = 220.0
     accel: float = 120.0
@@ -15,6 +16,11 @@ class Car:
     friction: float = 40.0
 
     def update(self, dt, controls, boost=False):
+        if self.oil_timer > 0:
+            self.oil_timer = max(0.0, self.oil_timer - dt)
+            grip = 0.3
+        else:
+            grip = 1.0
         if controls.get('accelerate'):
             self.speed += self.accel * dt * (1.5 if boost else 1.0)
         elif controls.get('brake'):
@@ -28,9 +34,9 @@ class Car:
 
         curve = self.track.curvature_at(self.z)
         if controls.get('left'):
-            self.x -= 1.5 * dt * (self.speed / self.max_speed)
+            self.x -= 1.5 * dt * (self.speed / self.max_speed) * grip
         if controls.get('right'):
-            self.x += 1.5 * dt * (self.speed / self.max_speed)
+            self.x += 1.5 * dt * (self.speed / self.max_speed) * grip
         # push car to outside of curve
         self.x -= curve * 0.5 * (self.speed / self.max_speed)
         self.x = max(-3.0, min(self.x, 3.0))

--- a/arcade/games/kart8/engine/renderer.py
+++ b/arcade/games/kart8/engine/renderer.py
@@ -2,11 +2,11 @@ import pygame
 
 
 class Renderer:
-    def __init__(self, screen, track):
-        self.screen = screen
+    def __init__(self, track):
         self.track = track
         self.scale = 200.0  # scaling factor for width
         self.cam_height = 1.0
+        self.screen = None
 
     def project(self, obj_z, obj_x, player):
         dz = obj_z - player.z
@@ -82,9 +82,27 @@ class Renderer:
         rect = pygame.Rect(width // 2 - 10, height - 40, 20, 40)
         pygame.draw.rect(self.screen, (0, 0, 255), rect)
 
-    def render(self, player, others=None):
+    def render_items(self, player, items):
+        colors = {
+            "boost": (255, 255, 0),
+            "oil": (0, 0, 0),
+            "shell": (255, 0, 0),
+        }
+        for item in items:
+            res = self.project(item["z"], item["x"], player)
+            if not res:
+                continue
+            sx, sy, scale = res
+            size = max(5, int(20 * scale / self.scale))
+            rect = pygame.Rect(int(sx) - size // 2, int(sy) - size, size, size)
+            pygame.draw.rect(self.screen, colors.get(item["type"], (255, 255, 255)), rect)
+
+    def render(self, surface, player, others=None, items=None):
+        self.screen = surface
         self.render_road(player)
         self.render_billboards(player)
+        if items:
+            self.render_items(player, items)
         if others:
             for obj in sorted(others, key=lambda o: -self.track.relative_distance(player.z, o.z)):
                 self.render_car(obj, player)

--- a/arcade/games/kart8/engine/track.py
+++ b/arcade/games/kart8/engine/track.py
@@ -17,6 +17,7 @@ class Track:
         self.cumulative = []
         self.total_length = 0.0
         self.billboards = []  # list of (z, x, color)
+        self.items = []  # list of dicts with keys type,z,x,speed etc
 
     def add(self, seg: Segment):
         self.segments.append(seg)
@@ -69,4 +70,12 @@ def create_demo_track():
         x = random.choice([-2.0, 2.0])
         color = random.choice(colors)
         track.billboards.append((z, x, color))
+
+    # place a few items along the track
+    track.items = []
+    for i in range(3):
+        track.items.append({"type": "boost", "z": 30 + i * 80, "x": 0.0})
+    for i in range(2):
+        track.items.append({"type": "oil", "z": 70 + i * 120, "x": 1.5})
+    track.items.append({"type": "shell", "z": 150, "x": -0.5, "speed": 90.0, "active": True})
     return track

--- a/arcade/games/kart8/game.py
+++ b/arcade/games/kart8/game.py
@@ -1,3 +1,4 @@
+import math
 import pygame
 from state import State
 from .engine.track import create_demo_track
@@ -6,44 +7,176 @@ from .engine.physics import Car, Ghost
 
 
 class KartGame(State):
-    def startup(self, screen, num_players: int = 1):
-        super().startup(screen, num_players)
+    def startup(self, screen, num_players: int = 1, items: bool = True, **opts):
+        super().startup(screen, num_players, **opts)
         self.track = create_demo_track()
-        self.player = Car(self.track)
-        self.ghost = Ghost(self.track)
-        self.renderer = Renderer(screen, self.track)
+        if not items:
+            self.track.items = []
+        self.items_enabled = items
+        self.players = [Car(self.track)]
+        if num_players > 1:
+            self.players.append(Car(self.track, color=(255, 255, 0)))
+            self.ghost = None
+        else:
+            self.ghost = Ghost(self.track)
+        self.laps = [0 for _ in self.players]
         self.font = pygame.font.SysFont("Courier", 20)
-        self.lap = 0
         self.hud_color = (0, 255, 0)
+        self.layout = "vertical"  # top/bottom by default
+        self.create_cameras()
+        self.build_minimap()
 
+    # ---- setup helpers -------------------------------------------------
+    def create_cameras(self):
+        w, h = self.screen.get_size()
+        self.renderers = []
+        self.cameras = []
+        if self.num_players == 1:
+            surf = pygame.Surface((w, h))
+            if pygame.display.get_surface():
+                surf = surf.convert()
+            self.cameras.append(surf)
+            self.renderers.append(Renderer(self.track))
+        else:
+            if self.layout == "vertical":
+                size = (w, h // 2)
+            else:
+                size = (w // 2, h)
+            for _ in range(2):
+                surf = pygame.Surface(size)
+                if pygame.display.get_surface():
+                    surf = surf.convert()
+                self.cameras.append(surf)
+                self.renderers.append(Renderer(self.track))
+
+    def build_minimap(self):
+        w, h = 80, 60
+        pts = []
+        x = y = 0.0
+        ang = 0.0
+        step = self.track.total_length / 200
+        z = 0.0
+        while z < self.track.total_length:
+            curve = self.track.curvature_at(z)
+            ang += curve * step * 40
+            x += math.cos(ang) * step
+            y += math.sin(ang) * step
+            pts.append((x, y))
+            z += step
+        xs = [p[0] for p in pts]
+        ys = [p[1] for p in pts]
+        minx, maxx = min(xs), max(xs)
+        miny, maxy = min(ys), max(ys)
+        scale = min((w - 10) / (maxx - minx + 1e-6), (h - 10) / (maxy - miny + 1e-6))
+        self.map_points = [
+            (int((px - minx) * scale) + 5, int((py - miny) * scale) + 5) for px, py in pts
+        ]
+        surf = pygame.Surface((w, h))
+        if pygame.display.get_surface():
+            surf = surf.convert()
+        surf.fill((0, 0, 0))
+        pygame.draw.lines(surf, (100, 100, 100), False, self.map_points, 1)
+        self.minimap_template = surf
+        self.map_step = step
+
+    # ---- input ---------------------------------------------------------
     def handle_keyboard(self, event):
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
-            self.done = True
-            self.next = "menu"
+        if event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_ESCAPE:
+                self.done = True
+                self.next = "menu"
+            elif event.key == pygame.K_TAB and self.num_players > 1:
+                self.layout = "horizontal" if self.layout == "vertical" else "vertical"
+                self.create_cameras()
 
+    # ---- game logic ----------------------------------------------------
     def update(self, dt):
         keys = pygame.key.get_pressed()
-        controls = {
+        # player 1 controls
+        controls1 = {
             'accelerate': keys[pygame.K_w],
             'brake': keys[pygame.K_s],
             'left': keys[pygame.K_a],
             'right': keys[pygame.K_d],
         }
-        boost = keys[pygame.K_LSHIFT]
-        prev_z = self.player.z
-        self.player.update(dt, controls, boost)
-        self.ghost.update(dt, self.player.z)
-        if prev_z > self.player.z:
-            self.lap += 1
+        boost1 = keys[pygame.K_LSHIFT]
+        prev_z1 = self.players[0].z
+        self.players[0].update(dt, controls1, boost1)
+        if prev_z1 > self.players[0].z:
+            self.laps[0] += 1
+
+        if self.num_players > 1:
+            controls2 = {
+                'accelerate': keys[pygame.K_UP],
+                'brake': keys[pygame.K_DOWN],
+                'left': keys[pygame.K_LEFT],
+                'right': keys[pygame.K_RIGHT],
+            }
+            boost2 = keys[pygame.K_RCTRL]
+            prev_z2 = self.players[1].z
+            self.players[1].update(dt, controls2, boost2)
+            if prev_z2 > self.players[1].z:
+                self.laps[1] += 1
+        elif self.ghost:
+            self.ghost.update(dt, self.players[0].z)
+
+        # move shells and handle collisions
+        if self.items_enabled:
+            for item in self.track.items:
+                if item.get("type") == "shell" and item.get("active", True):
+                    item["z"] = (item["z"] + item.get("speed", 0) * dt) % self.track.total_length
+            for p in self.players:
+                for item in self.track.items:
+                    if not item.get("active", True):
+                        continue
+                    dz = self.track.relative_distance(p.z, item["z"])
+                    if dz < 5 and abs(p.x - item["x"]) < 0.6:
+                        t = item["type"]
+                        if t == "boost":
+                            p.speed = min(p.speed + 80, p.max_speed * 1.2)
+                        elif t == "oil":
+                            p.oil_timer = 2.0
+                        elif t == "shell":
+                            p.speed *= 0.5
+                            item["active"] = False
+            self.track.items = [i for i in self.track.items if i.get("active", True)]
+
+    # ---- drawing -------------------------------------------------------
+    def draw_hud(self, surface, player, lap):
+        lap_text = self.font.render(f"LAP {lap + 1}", True, self.hud_color)
+        surface.blit(lap_text, (10, 10))
+        speed_text = self.font.render(f"{int(player.speed)}", True, self.hud_color)
+        surface.blit(speed_text, (10, 40))
+        if self.minimap_template:
+            m = self.minimap_template.copy()
+            idx = int(player.z / self.map_step) % len(self.map_points)
+            pygame.draw.circle(m, player.color, self.map_points[idx], 2)
+            surface.blit(m, (surface.get_width() - m.get_width() - 5, 5))
 
     def draw(self):
         self.screen.fill((0, 0, 0))
-        self.renderer.render(self.player, [self.ghost])
-        lap_text = self.font.render(f"LAP {self.lap + 1}", True, self.hud_color)
-        self.screen.blit(lap_text, (10, 10))
-        speed_text = self.font.render(f"{int(self.player.speed)}", True, self.hud_color)
-        self.screen.blit(speed_text, (10, 40))
+        if self.num_players == 1:
+            self.renderers[0].render(self.cameras[0], self.players[0],
+                                    [self.ghost] if self.ghost else None,
+                                    self.track.items if self.items_enabled else None)
+            self.draw_hud(self.cameras[0], self.players[0], self.laps[0])
+            self.screen.blit(self.cameras[0], (0, 0))
+        else:
+            for i in range(2):
+                others = [self.players[1 - i]]
+                self.renderers[i].render(self.cameras[i], self.players[i], others,
+                                        self.track.items if self.items_enabled else None)
+                self.draw_hud(self.cameras[i], self.players[i], self.laps[i])
+            if self.layout == "vertical":
+                h = self.screen.get_height() // 2
+                self.screen.blit(self.cameras[0], (0, 0))
+                self.screen.blit(self.cameras[1], (0, h))
+            else:
+                w = self.screen.get_width() // 2
+                self.screen.blit(self.cameras[0], (0, 0))
+                self.screen.blit(self.cameras[1], (w, 0))
 
 
 # expose Game class for loader
 Game = KartGame
+

--- a/arcade/main.py
+++ b/arcade/main.py
@@ -104,7 +104,9 @@ def main():
                 for state in states.values():
                     state.screen = screen
             if next_state:
-                next_state.startup(screen, current_state.num_players)
+                # pass through any options the current state collected
+                opts = getattr(current_state, "game_options", {})
+                next_state.startup(screen, current_state.num_players, **opts)
                 current_state = next_state
 
     pygame.quit()

--- a/arcade/state.py
+++ b/arcade/state.py
@@ -8,13 +8,21 @@ class State:
         self.next = None
         self.screen = None
         self.num_players = 1
+        # arbitrary options passed when the state starts
+        self.options = {}
 
-    def startup(self, screen, num_players: int = 1):
-        """Called when the state starts up."""
+    def startup(self, screen, num_players: int = 1, **options):
+        """Called when the state starts up.
+
+        Additional keyword *options* are stored on the state so that
+        launcher menus can pass configuration such as enabling items in
+        games without changing the call signature for every state.
+        """
         self.done = False
         self.quit = False
         self.screen = screen
         self.num_players = num_players
+        self.options = options
 
     def cleanup(self):
         """Cleanup before the state is destroyed or switched."""


### PR DESCRIPTION
## Summary
- Allow states to receive arbitrary startup options and pass them through the main menu
- Add split-screen multiplayer with HUDs and optional items to kart8
- Render track items and oil effect, support toggling layout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e511b050833098ac72e8580a99a0