### PR TITLE
Add persistence and settings to Kart 8-Bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,7 @@ Currently included:
   persistent high score tracking.
 - Wyrm – Centipede-like shooter with splitting segments and rune blocks.
 - Virus – Matrix-themed Dr. Mario-style pill matcher.
+- Kart 8-Bit – retro-inspired split-screen kart racer. WASD or arrow keys to steer,
+  Shift/Right Ctrl to boost, Tab to swap splitscreen.
 
 Contributions and new mini-games are welcome!

--- a/arcade/games/kart8/engine/physics.py
+++ b/arcade/games/kart8/engine/physics.py
@@ -46,15 +46,17 @@ class Car:
 
 class Ghost:
     """Simple rubber-band opponent."""
-    def __init__(self, track):
+
+    def __init__(self, track, difficulty: float = 1.0):
         self.track = track
         self.z = 20.0
         self.x = 0.0
         self.speed = 80.0
         self.color = (255, 0, 0)
+        self.difficulty = difficulty
 
     def update(self, dt, target_z):
         diff = self.track.relative_distance(self.z, target_z)
-        base = 100.0
-        self.speed = base + diff * 0.3
+        base = 100.0 * self.difficulty
+        self.speed = base + diff * 0.3 * self.difficulty
         self.z = (self.z + self.speed * dt) % self.track.total_length

--- a/arcade/games/kart8/tests/test_smoke.py
+++ b/arcade/games/kart8/tests/test_smoke.py
@@ -1,11 +1,17 @@
+import os
+
 import pygame
+
 from ..game import Game
 
 def test_smoke():
+    os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
     pygame.init()
-    screen = pygame.Surface((320, 240))
+    pygame.display.set_mode((320, 240))
     g = Game()
+    screen = pygame.display.get_surface()
     g.startup(screen)
     g.update(0.016)
     g.draw()
+    pygame.display.quit()
     pygame.quit()

--- a/arcade/main.py
+++ b/arcade/main.py
@@ -66,7 +66,7 @@ def main():
 
     running = True
     while running:
-        dt = clock.tick(60) / 1000.0
+        dt = clock.tick(getattr(current_state, "fps_cap", 60)) / 1000.0
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False


### PR DESCRIPTION
## Summary
- Add JSON persistence for Kart 8-Bit settings and lap times
- Implement adjustable difficulty, layout, FPS cap and volume with first-run controls overlay
- Support per-state FPS caps in main loop and update smoke test

## Testing
- `python -m py_compile arcade/games/kart8/game.py arcade/games/kart8/engine/physics.py arcade/main.py arcade/games/kart8/tests/test_smoke.py`
- `pytest -q`
- Unable to install pyflakes: `pip install pyflakes` (HTTP 403)


------
https://chatgpt.com/codex/tasks/task_e_6896e6d8bc5c83308e13b3a1d1a1b992