### PR TITLE
Add placeholder sprite generator for kart8

### DIFF
--- a/arcade/games/kart8/assets/.gitignore
+++ b/arcade/games/kart8/assets/.gitignore
@@ -1,0 +1,1 @@
+generated/

--- a/arcade/games/kart8/engine/renderer.py
+++ b/arcade/games/kart8/engine/renderer.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pygame
 
 
@@ -7,6 +9,22 @@ class Renderer:
         self.scale = 200.0  # scaling factor for width
         self.cam_height = 1.0
         self.screen = None
+
+        assets = Path(__file__).resolve().parents[1] / "assets" / "generated"
+        self.player_img = self._load_image(assets / "car_blue.png")
+        self.enemy_img = self._load_image(assets / "car_red.png")
+        self.item_imgs = {
+            "boost": self._load_image(assets / "boost.png"),
+            "oil": self._load_image(assets / "oil.png"),
+            "shell": self._load_image(assets / "shell.png"),
+        }
+
+    @staticmethod
+    def _load_image(path):
+        try:
+            return pygame.image.load(str(path)).convert_alpha()
+        except Exception:
+            return None
 
     def project(self, obj_z, obj_x, player):
         dz = obj_z - player.z
@@ -74,13 +92,22 @@ class Renderer:
         sx, sy, scale = res
         w = int(20 * scale / self.scale)
         h = int(40 * scale / self.scale)
-        rect = pygame.Rect(int(sx) - w // 2, int(sy) - h, w, h)
-        pygame.draw.rect(self.screen, car.color, rect)
+        if self.enemy_img:
+            img = pygame.transform.scale(self.enemy_img, (w, h))
+            rect = img.get_rect(midbottom=(int(sx), int(sy)))
+            self.screen.blit(img, rect)
+        else:
+            rect = pygame.Rect(int(sx) - w // 2, int(sy) - h, w, h)
+            pygame.draw.rect(self.screen, car.color, rect)
 
     def render_player_car(self):
         width, height = self.screen.get_size()
-        rect = pygame.Rect(width // 2 - 10, height - 40, 20, 40)
-        pygame.draw.rect(self.screen, (0, 0, 255), rect)
+        if self.player_img:
+            rect = self.player_img.get_rect(midbottom=(width // 2, height))
+            self.screen.blit(self.player_img, rect)
+        else:
+            rect = pygame.Rect(width // 2 - 10, height - 40, 20, 40)
+            pygame.draw.rect(self.screen, (0, 0, 255), rect)
 
     def render_items(self, player, items):
         colors = {
@@ -94,8 +121,14 @@ class Renderer:
                 continue
             sx, sy, scale = res
             size = max(5, int(20 * scale / self.scale))
-            rect = pygame.Rect(int(sx) - size // 2, int(sy) - size, size, size)
-            pygame.draw.rect(self.screen, colors.get(item["type"], (255, 255, 255)), rect)
+            img = self.item_imgs.get(item["type"])
+            if img:
+                img = pygame.transform.scale(img, (size, size))
+                rect = img.get_rect(midbottom=(int(sx), int(sy)))
+                self.screen.blit(img, rect)
+            else:
+                rect = pygame.Rect(int(sx) - size // 2, int(sy) - size, size, size)
+                pygame.draw.rect(self.screen, colors.get(item["type"], (255, 255, 255)), rect)
 
     def render(self, surface, player, others=None, items=None):
         self.screen = surface

--- a/arcade/games/kart8/tools/generate_placeholders.py
+++ b/arcade/games/kart8/tools/generate_placeholders.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Generate simple 8-bit style placeholder sprites.
+
+The script creates small PNG images with blocky stripes and saves them
+under ``assets/generated``.  These files are optional; the game falls back
+to primitive shapes if they are missing.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# Prefer Pillow if available, otherwise use pygame.
+try:
+    from PIL import Image, ImageDraw  # type: ignore
+    USE_PIL = True
+except Exception:  # pragma: no cover - Pillow not installed
+    USE_PIL = False
+
+if not USE_PIL:
+    os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+    import pygame
+    pygame.init()
+
+OUTPUT_DIR = Path(__file__).resolve().parents[1] / "assets" / "generated"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def make_striped_block(size: tuple[int, int], colors: tuple[tuple[int, int, int], tuple[int, int, int]], stripe: int = 4):
+    """Create a surface/image filled with stripes."""
+    if USE_PIL:
+        img = Image.new("RGBA", size, colors[0])
+        draw = ImageDraw.Draw(img)
+        for x in range(0, size[0], stripe * 2):
+            draw.rectangle((x, 0, x + stripe - 1, size[1]), fill=colors[1])
+        return img
+    else:  # pragma: no cover - exercised when Pillow not present
+        surf = pygame.Surface(size)
+        surf.fill(colors[0])
+        for x in range(0, size[0], stripe * 2):
+            pygame.draw.rect(surf, colors[1], (x, 0, stripe, size[1]))
+        return surf
+
+
+SPRITES = [
+    ("car_blue.png", (32, 32), ((0, 0, 255), (255, 255, 255))),
+    ("car_red.png", (32, 32), ((255, 0, 0), (255, 255, 255))),
+    ("boost.png", (16, 16), ((255, 255, 0), (255, 255, 255))),
+    ("oil.png", (16, 16), ((0, 0, 0), (80, 80, 80))),
+    ("shell.png", (16, 16), ((255, 0, 0), (255, 255, 255))),
+]
+
+
+for name, size, colors in SPRITES:
+    img = make_striped_block(size, colors)
+    path = OUTPUT_DIR / name
+    if USE_PIL:
+        img.save(path)
+    else:  # pragma: no cover - Pillow not present
+        pygame.image.save(img, path)
+
+if not USE_PIL:
+    pygame.quit()
+
+print(f"Generated {len(SPRITES)} placeholder images in {OUTPUT_DIR}")


### PR DESCRIPTION
## Summary
- add tool to generate 8-bit style placeholder sprites for kart8
- renderers optionally load generated sprites and fall back to shapes
- ignore generated assets in version control

## Testing
- `pytest`
- `python arcade/games/kart8/tools/generate_placeholders.py`


------
https://chatgpt.com/codex/tasks/task_e_6896e891e928833094c07360360fee51