### PR TITLE
feat: add shared theme and pause menu utilities

### DIFF
--- a/arcade/arcade_menu.py
+++ b/arcade/arcade_menu.py
@@ -5,6 +5,12 @@ import json
 import math
 import pygame
 from state import State
+from common.theme import (
+    ACCENT_COLOR,
+    BG_COLOR,
+    PRIMARY_COLOR,
+    get_font,
+)
 
 
 class MainMenuState(State):
@@ -17,9 +23,9 @@ class MainMenuState(State):
         self.font = None
         self.title_font = None
         self.rain_font = None
-        self.normal_color = (0, 155, 0)
-        self.highlight_color = (0, 255, 0)
-        self.bg_color = (0, 0, 0)
+        self.normal_color = ACCENT_COLOR
+        self.highlight_color = PRIMARY_COLOR
+        self.bg_color = BG_COLOR
         self.rain_glyphs = []
         self.rain_chars = string.ascii_letters + string.digits
         self.rain_surfaces = {}
@@ -40,9 +46,9 @@ class MainMenuState(State):
         super().startup(screen, num_players)
         self.num_players = 1
         self.game_options = {}
-        self.font = pygame.font.SysFont("Courier", 32)
-        self.title_font = pygame.font.SysFont("Courier", 48, bold=True)
-        self.rain_font = pygame.font.SysFont("Courier", 20)
+        self.font = get_font(32)
+        self.title_font = get_font(48, bold=True)
+        self.rain_font = get_font(20)
         base_dir = os.path.join(os.path.dirname(__file__), "games")
         entries = []
         for name in os.listdir(base_dir):
@@ -120,7 +126,7 @@ class MainMenuState(State):
             center=(width // 2, height // 2)
         )
         self.title_base = self.title_font.render(
-            "ARCADE TERMINAL", True, (0, 200, 0)
+            "ARCADE TERMINAL", True, PRIMARY_COLOR
         ).convert_alpha()
         self.title_rect = self.title_base.get_rect(center=(width // 2, height // 5))
 

--- a/arcade/common/__init__.py
+++ b/arcade/common/__init__.py
@@ -1,0 +1,1 @@
+"""Common utilities for arcade games."""

--- a/arcade/common/theme.py
+++ b/arcade/common/theme.py
@@ -1,0 +1,76 @@
+import pygame
+
+# Matrix-style color palette
+BG_COLOR = (0, 0, 0)
+PRIMARY_COLOR = (0, 255, 0)
+ACCENT_COLOR = (0, 155, 0)
+
+
+def get_font(size: int, bold: bool = False) -> pygame.font.Font:
+    """Return a Courier font at the given *size*.
+
+    All arcade games use the same monospace font to maintain the
+    terminal-style aesthetic.
+    """
+    return pygame.font.SysFont("Courier", size, bold=bold)
+
+
+def draw_text(
+    surface: pygame.surface.Surface,
+    text: str,
+    pos: tuple[int, int],
+    size: int,
+    color: tuple[int, int, int] = PRIMARY_COLOR,
+    *,
+    bold: bool = False,
+    center: bool = False,
+) -> pygame.rect.Rect:
+    """Draw *text* to *surface* using the shared font and colors.
+
+    Parameters
+    ----------
+    surface:
+        The target surface.
+    text:
+        Text string to render.
+    pos:
+        Position of the text.  Interpreted as the centre if *center* is
+        true, otherwise the top-left corner.
+    size:
+        Font size.
+    color:
+        RGB text colour.
+    bold:
+        Whether to render in bold.
+    center:
+        Whether *pos* is treated as the centre point.
+
+    Returns the rectangle of the rendered text.
+    """
+    font = get_font(size, bold=bold)
+    text_surf = font.render(text, True, color)
+    rect = text_surf.get_rect()
+    if center:
+        rect.center = pos
+    else:
+        rect.topleft = pos
+    surface.blit(text_surf, rect)
+    return rect
+
+
+def terminal_panel(
+    surface: pygame.surface.Surface,
+    rect: pygame.rect.Rect,
+    *,
+    border_color: tuple[int, int, int] = ACCENT_COLOR,
+    fill_color: tuple[int, int, int] | None = None,
+    border_width: int = 2,
+) -> None:
+    """Draw a simple terminal-style panel.
+
+    If *fill_color* is provided the rectangle is filled before drawing the
+    border.
+    """
+    if fill_color is not None:
+        pygame.draw.rect(surface, fill_color, rect)
+    pygame.draw.rect(surface, border_color, rect, border_width)

--- a/arcade/common/ui.py
+++ b/arcade/common/ui.py
@@ -1,0 +1,61 @@
+import pygame
+
+from .theme import ACCENT_COLOR, PRIMARY_COLOR, draw_text
+
+
+class PauseMenu:
+    """Reusable pause menu handling keyboard and gamepad input."""
+
+    def __init__(self, options: list[str], font_size: int = 32):
+        self.options = options
+        self.font_size = font_size
+        self.index = 0
+        self.normal_color = ACCENT_COLOR
+        self.highlight_color = PRIMARY_COLOR
+
+    def handle_keyboard(self, event: pygame.event.Event) -> str | None:
+        if event.type != pygame.KEYDOWN:
+            return None
+        if event.key in (pygame.K_UP, pygame.K_w):
+            self.index = (self.index - 1) % len(self.options)
+        elif event.key in (pygame.K_DOWN, pygame.K_s):
+            self.index = (self.index + 1) % len(self.options)
+        elif event.key == pygame.K_RETURN:
+            return self.options[self.index]
+        elif event.key == pygame.K_ESCAPE:
+            return "Resume"
+        return None
+
+    def handle_gamepad(self, event: pygame.event.Event) -> str | None:
+        if event.type in (pygame.JOYAXISMOTION, pygame.JOYHATMOTION):
+            if event.type == pygame.JOYHATMOTION:
+                _, y = event.value
+                vert = -y
+            else:
+                if event.axis != 1:
+                    return None
+                vert = event.value
+            if vert < -0.5 or vert == -1:
+                self.index = (self.index - 1) % len(self.options)
+            elif vert > 0.5 or vert == 1:
+                self.index = (self.index + 1) % len(self.options)
+        elif event.type == pygame.JOYBUTTONDOWN:
+            if event.button == 0:
+                return self.options[self.index]
+            elif event.button in (1, 7, 9):
+                return "Resume"
+        return None
+
+    def draw(self, surface: pygame.surface.Surface) -> None:
+        width, height = surface.get_size()
+        for i, option in enumerate(self.options):
+            color = self.highlight_color if i == self.index else self.normal_color
+            prefix = "> " if i == self.index else "  "
+            draw_text(
+                surface,
+                f"{prefix}{option}",
+                (width // 2, height // 2 + i * self.font_size),
+                self.font_size,
+                color,
+                center=True,
+            )

--- a/arcade/games/game_collectdots/game.py
+++ b/arcade/games/game_collectdots/game.py
@@ -4,6 +4,8 @@ from datetime import datetime
 import pygame
 from state import State
 from utils.persistence import load_json, save_json
+from common.theme import BG_COLOR, PRIMARY_COLOR, draw_text, get_font
+from common.ui import PauseMenu
 
 SETTINGS_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "settings.json")
 
@@ -11,8 +13,7 @@ SETTINGS_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "settings.js
 class CollectDotsState(State):
     def startup(self, screen, num_players: int = 1):
         super().startup(screen, num_players)
-        self.font = pygame.font.SysFont("Courier", 24)
-        self.big_font = pygame.font.SysFont("Courier", 32)
+        self.font = get_font(24)
         self.score = 0
         self.score2 = 0
         cx, cy = screen.get_width() // 2, screen.get_height() // 2
@@ -26,14 +27,10 @@ class CollectDotsState(State):
         self.respawn_dot()
         self.speed = 200
         self.state = "instructions"
-        self.pause_options = [
-            "Resume",
-            "Volume -",
-            "Volume +",
-            "Fullscreen",
-            "Quit",
-        ]
-        self.pause_index = 0
+        self.pause_menu = PauseMenu(
+            ["Resume", "Volume -", "Volume +", "Fullscreen", "Quit"],
+            font_size=32,
+        )
         self.hs_path = os.path.join(os.path.dirname(__file__), "highscores.json")
         self.data = load_json(
             self.hs_path, {"highscore": 0, "plays": 0, "last_played": None}
@@ -65,39 +62,32 @@ class CollectDotsState(State):
         elif self.state == "play":
             if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
                 self.state = "pause"
-                self.pause_index = 0
+                self.pause_menu.index = 0
         elif self.state == "pause":
-            if event.type == pygame.KEYDOWN:
-                if event.key in (pygame.K_UP, pygame.K_w):
-                    self.pause_index = (self.pause_index - 1) % len(self.pause_options)
-                elif event.key in (pygame.K_DOWN, pygame.K_s):
-                    self.pause_index = (self.pause_index + 1) % len(self.pause_options)
-                elif event.key == pygame.K_RETURN:
-                    choice = self.pause_options[self.pause_index]
-                    if choice == "Resume":
-                        self.state = "play"
-                    elif choice == "Quit":
-                        self.update_stats()
-                        self.done = True
-                        self.next = "menu"
-                    elif choice == "Fullscreen":
-                        pygame.display.toggle_fullscreen()
-                        self.settings["fullscreen"] = not self.settings.get(
-                            "fullscreen", False
-                        )
-                        save_json(SETTINGS_PATH, self.settings)
-                    elif choice == "Volume +":
-                        vol = min(1.0, self.settings.get("sound_volume", 1.0) + 0.1)
-                        self.settings["sound_volume"] = round(vol, 2)
-                        pygame.mixer.music.set_volume(vol)
-                        save_json(SETTINGS_PATH, self.settings)
-                    elif choice == "Volume -":
-                        vol = max(0.0, self.settings.get("sound_volume", 1.0) - 0.1)
-                        self.settings["sound_volume"] = round(vol, 2)
-                        pygame.mixer.music.set_volume(vol)
-                        save_json(SETTINGS_PATH, self.settings)
-                elif event.key == pygame.K_ESCAPE:
+            choice = self.pause_menu.handle_keyboard(event)
+            if choice:
+                if choice == "Resume":
                     self.state = "play"
+                elif choice == "Quit":
+                    self.update_stats()
+                    self.done = True
+                    self.next = "menu"
+                elif choice == "Fullscreen":
+                    pygame.display.toggle_fullscreen()
+                    self.settings["fullscreen"] = not self.settings.get(
+                        "fullscreen", False
+                    )
+                    save_json(SETTINGS_PATH, self.settings)
+                elif choice == "Volume +":
+                    vol = min(1.0, self.settings.get("sound_volume", 1.0) + 0.1)
+                    self.settings["sound_volume"] = round(vol, 2)
+                    pygame.mixer.music.set_volume(vol)
+                    save_json(SETTINGS_PATH, self.settings)
+                elif choice == "Volume -":
+                    vol = max(0.0, self.settings.get("sound_volume", 1.0) - 0.1)
+                    self.settings["sound_volume"] = round(vol, 2)
+                    pygame.mixer.music.set_volume(vol)
+                    save_json(SETTINGS_PATH, self.settings)
 
     def handle_gamepad(self, event):
         if self.state == "instructions":
@@ -110,7 +100,7 @@ class CollectDotsState(State):
         elif self.state == "play":
             if event.type == pygame.JOYBUTTONDOWN and event.button == 7:
                 self.state = "pause"
-                self.pause_index = 0
+                self.pause_menu.index = 0
             elif event.type == pygame.JOYAXISMOTION:
                 if event.axis in (0, 1):
                     dirs = self.pad_dirs.setdefault(event.joy, [0, 0])
@@ -123,45 +113,30 @@ class CollectDotsState(State):
                 dirs[0] = event.value[0]
                 dirs[1] = -event.value[1]
         elif self.state == "pause":
-            if event.type in (pygame.JOYAXISMOTION, pygame.JOYHATMOTION):
-                if event.type == pygame.JOYHATMOTION:
-                    _, y = event.value
-                    vert = -y
-                else:
-                    if event.axis != 1:
-                        return
-                    vert = event.value
-                if vert < -0.5 or vert == -1:
-                    self.pause_index = (self.pause_index - 1) % len(self.pause_options)
-                elif vert > 0.5 or vert == 1:
-                    self.pause_index = (self.pause_index + 1) % len(self.pause_options)
-            elif event.type == pygame.JOYBUTTONDOWN:
-                if event.button == 0:
-                    choice = self.pause_options[self.pause_index]
-                    if choice == "Resume":
-                        self.state = "play"
-                    elif choice == "Quit":
-                        self.update_stats()
-                        self.done = True
-                        self.next = "menu"
-                    elif choice == "Fullscreen":
-                        pygame.display.toggle_fullscreen()
-                        self.settings["fullscreen"] = not self.settings.get(
-                            "fullscreen", False
-                        )
-                        save_json(SETTINGS_PATH, self.settings)
-                    elif choice == "Volume +":
-                        vol = min(1.0, self.settings.get("sound_volume", 1.0) + 0.1)
-                        self.settings["sound_volume"] = round(vol, 2)
-                        pygame.mixer.music.set_volume(vol)
-                        save_json(SETTINGS_PATH, self.settings)
-                    elif choice == "Volume -":
-                        vol = max(0.0, self.settings.get("sound_volume", 1.0) - 0.1)
-                        self.settings["sound_volume"] = round(vol, 2)
-                        pygame.mixer.music.set_volume(vol)
-                        save_json(SETTINGS_PATH, self.settings)
-                elif event.button in (1, 7, 9):
+            choice = self.pause_menu.handle_gamepad(event)
+            if choice:
+                if choice == "Resume":
                     self.state = "play"
+                elif choice == "Quit":
+                    self.update_stats()
+                    self.done = True
+                    self.next = "menu"
+                elif choice == "Fullscreen":
+                    pygame.display.toggle_fullscreen()
+                    self.settings["fullscreen"] = not self.settings.get(
+                        "fullscreen", False
+                    )
+                    save_json(SETTINGS_PATH, self.settings)
+                elif choice == "Volume +":
+                    vol = min(1.0, self.settings.get("sound_volume", 1.0) + 0.1)
+                    self.settings["sound_volume"] = round(vol, 2)
+                    pygame.mixer.music.set_volume(vol)
+                    save_json(SETTINGS_PATH, self.settings)
+                elif choice == "Volume -":
+                    vol = max(0.0, self.settings.get("sound_volume", 1.0) - 0.1)
+                    self.settings["sound_volume"] = round(vol, 2)
+                    pygame.mixer.music.set_volume(vol)
+                    save_json(SETTINGS_PATH, self.settings)
 
     def update_stats(self):
         best = self.score
@@ -232,56 +207,60 @@ class CollectDotsState(State):
                 self.respawn_dot()
 
     def draw(self):
-        self.screen.fill((0, 0, 0))
+        self.screen.fill(BG_COLOR)
         if self.state == "instructions":
             if self.num_players == 2:
-                text1 = self.big_font.render("P1: Arrows  P2: WASD", True, (0, 255, 0))
+                draw_text(
+                    self.screen,
+                    "P1: Arrows  P2: WASD",
+                    (
+                        self.screen.get_width() // 2,
+                        self.screen.get_height() // 2 - 20,
+                    ),
+                    32,
+                    PRIMARY_COLOR,
+                    center=True,
+                )
             else:
-                text1 = self.big_font.render(
-                    "Use arrow keys to move the square", True, (0, 255, 0)
+                draw_text(
+                    self.screen,
+                    "Use arrow keys to move the square",
+                    (
+                        self.screen.get_width() // 2,
+                        self.screen.get_height() // 2 - 20,
+                    ),
+                    32,
+                    PRIMARY_COLOR,
+                    center=True,
                 )
-            text2 = self.big_font.render("Press any key to start", True, (0, 255, 0))
-            rect1 = text1.get_rect(
-                center=(
-                    self.screen.get_width() // 2,
-                    self.screen.get_height() // 2 - 20,
-                )
-            )
-            rect2 = text2.get_rect(
-                center=(
+            draw_text(
+                self.screen,
+                "Press any key to start",
+                (
                     self.screen.get_width() // 2,
                     self.screen.get_height() // 2 + 20,
-                )
+                ),
+                32,
+                PRIMARY_COLOR,
+                center=True,
             )
-            self.screen.blit(text1, rect1)
-            self.screen.blit(text2, rect2)
             return
 
-        pygame.draw.rect(self.screen, (0, 255, 0), self.player)
+        pygame.draw.rect(self.screen, PRIMARY_COLOR, self.player)
         if self.num_players == 2 and self.player2:
             pygame.draw.rect(self.screen, (0, 0, 255), self.player2)
         pygame.draw.ellipse(self.screen, (255, 0, 0), self.dot)
         if self.num_players == 2:
-            score1 = self.font.render(f"P1: {self.score}", True, (0, 255, 0))
-            score2 = self.font.render(f"P2: {self.score2}", True, (0, 255, 0))
+            score1 = self.font.render(f"P1: {self.score}", True, PRIMARY_COLOR)
+            score2 = self.font.render(f"P2: {self.score2}", True, PRIMARY_COLOR)
             self.screen.blit(score1, (10, 10))
             rect2 = score2.get_rect(topright=(self.screen.get_width() - 10, 10))
             self.screen.blit(score2, rect2)
         else:
-            score_text = self.font.render(f"Score: {self.score}", True, (0, 255, 0))
+            score_text = self.font.render(f"Score: {self.score}", True, PRIMARY_COLOR)
             self.screen.blit(score_text, (10, 10))
 
         if self.state == "pause":
             self.overlay.fill((0, 0, 0, 200))
+            self.pause_menu.draw(self.overlay)
             self.screen.blit(self.overlay, (0, 0))
-            for i, option in enumerate(self.pause_options):
-                color = (0, 255, 0) if i == self.pause_index else (0, 155, 0)
-                prefix = "> " if i == self.pause_index else "  "
-                text = self.big_font.render(prefix + option, True, color)
-                rect = text.get_rect(
-                    center=(
-                        self.screen.get_width() // 2,
-                        self.screen.get_height() // 2 + i * 40,
-                    )
-                )
-                self.screen.blit(text, rect)

--- a/arcade/settings_state.py
+++ b/arcade/settings_state.py
@@ -2,6 +2,7 @@ import os
 import pygame
 from state import State
 from utils.persistence import load_json, save_json
+from common.theme import ACCENT_COLOR, BG_COLOR, PRIMARY_COLOR, draw_text
 
 SETTINGS_PATH = os.path.join(os.path.dirname(__file__), "settings.json")
 DEFAULT_SETTINGS = {
@@ -16,7 +17,6 @@ RESOLUTIONS = [(640, 480), (800, 600)]
 class SettingsState(State):
     def startup(self, screen, num_players: int = 1):
         super().startup(screen, num_players)
-        self.font = pygame.font.SysFont("Courier", 32)
         self.index = 0
         self.settings = load_json(SETTINGS_PATH, DEFAULT_SETTINGS)
         size = tuple(self.settings.get("window_size", RESOLUTIONS[1]))
@@ -90,10 +90,10 @@ class SettingsState(State):
             pygame.mixer.music.set_volume(self.settings["sound_volume"])
 
     def draw(self):
-        self.screen.fill((0, 0, 0))
+        self.screen.fill(BG_COLOR)
         width, height = self.screen.get_size()
         for i, option in enumerate(self.options):
-            color = (0, 255, 0) if i == self.index else (0, 155, 0)
+            color = PRIMARY_COLOR if i == self.index else ACCENT_COLOR
             prefix = "> " if i == self.index else "  "
             if option == "Fullscreen":
                 value = "On" if self.settings.get("fullscreen", False) else "Off"
@@ -104,6 +104,11 @@ class SettingsState(State):
                 value = f"{self.settings.get('sound_volume', 1.0):.1f}"
             else:
                 value = ""
-            text = self.font.render(f"{prefix}{option} {value}", True, color)
-            rect = text.get_rect(center=(width // 2, height // 3 + i * 40))
-            self.screen.blit(text, rect)
+            draw_text(
+                self.screen,
+                f"{prefix}{option} {value}",
+                (width // 2, height // 3 + i * 40),
+                32,
+                color,
+                center=True,
+            )


### PR DESCRIPTION
## Summary
- centralize Matrix-style colors and font helpers in `common.theme`
- add reusable `PauseMenu` in `common.ui`
- refactor menu, settings and CollectDots game to use shared theme/UI

## Testing
- `python -m black arcade/common/theme.py arcade/common/ui.py arcade/arcade_menu.py arcade/settings_state.py arcade/games/game_collectdots/game.py`
- `ruff check arcade/common/theme.py arcade/common/ui.py arcade/arcade_menu.py arcade/settings_state.py arcade/games/game_collectdots/game.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689824332e60833094b314b670243a8c