### PR TITLE
Add Bomberman game scaffolding

### DIFF
--- a/arcade/games/bomberman/__init__.py
+++ b/arcade/games/bomberman/__init__.py
@@ -1,0 +1,5 @@
+"""Matrix-themed Bomberman game module."""
+
+from .bomberman import BombermanGame
+
+__all__ = ["BombermanGame"]

--- a/arcade/games/bomberman/bomb.py
+++ b/arcade/games/bomberman/bomb.py
@@ -1,0 +1,38 @@
+"""Bomb logic for Bomberman."""
+from __future__ import annotations
+
+import pygame
+
+from .level import TILE_SIZE, Level, BRICK, EMPTY
+from .explosion import Explosion
+
+
+class Bomb:
+    def __init__(self, x: int, y: int, fuse_ms: int, radius: int, *, owner=None):
+        self.x = x
+        self.y = y
+        self.timer = fuse_ms / 1000.0
+        self.radius = radius
+        self.owner = owner
+        self.image: pygame.surface.Surface | None = None
+
+    def update(self, dt: float) -> bool:
+        self.timer -= dt
+        return self.timer <= 0
+
+    def explode(self, level: Level) -> list[Explosion]:
+        tiles = [(self.x, self.y)]
+        dirs = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+        for dx, dy in dirs:
+            for i in range(1, self.radius + 1):
+                nx, ny = self.x + dx * i, self.y + dy * i
+                if level.is_blocked(nx, ny):
+                    if level.grid[ny][nx] == BRICK:
+                        level.destroy(nx, ny)
+                        tiles.append((nx, ny))
+                    break
+                tiles.append((nx, ny))
+        return [Explosion(x, y) for x, y in tiles]
+
+    def draw(self, surface: pygame.surface.Surface, image: pygame.surface.Surface) -> None:
+        surface.blit(image, (self.x * TILE_SIZE, self.y * TILE_SIZE))

--- a/arcade/games/bomberman/bomb.py
+++ b/arcade/games/bomberman/bomb.py
@@ -1,9 +1,10 @@
 """Bomb logic for Bomberman."""
+
 from __future__ import annotations
 
 import pygame
 
-from .level import TILE_SIZE, Level, BRICK, EMPTY
+from .level import TILE_SIZE, Level, BRICK
 from .explosion import Explosion
 
 
@@ -34,5 +35,7 @@ class Bomb:
                 tiles.append((nx, ny))
         return [Explosion(x, y) for x, y in tiles]
 
-    def draw(self, surface: pygame.surface.Surface, image: pygame.surface.Surface) -> None:
+    def draw(
+        self, surface: pygame.surface.Surface, image: pygame.surface.Surface
+    ) -> None:
         surface.blit(image, (self.x * TILE_SIZE, self.y * TILE_SIZE))

--- a/arcade/games/bomberman/bomberman.py
+++ b/arcade/games/bomberman/bomberman.py
@@ -1,4 +1,5 @@
 """Matrix-themed Bomberman clone scaffolding."""
+
 from __future__ import annotations
 
 import os
@@ -52,9 +53,7 @@ class BombermanGame(State):
             right=pygame.K_RIGHT,
             bomb=pygame.K_SPACE,
         )
-        self.players.append(
-            Player(1, 1, p1_controls, self.assets["player1"])
-        )
+        self.players.append(Player(1, 1, p1_controls, self.assets["player1"]))
         if self.num_players == 2:
             p2_controls = Controls(
                 up=pygame.K_w,
@@ -100,7 +99,12 @@ class BombermanGame(State):
         }
 
         # add simple details
-        pygame.draw.circle(assets["bomb"], (150, 150, 150), (TILE_SIZE // 2, TILE_SIZE // 2), TILE_SIZE // 2)
+        pygame.draw.circle(
+            assets["bomb"],
+            (150, 150, 150),
+            (TILE_SIZE // 2, TILE_SIZE // 2),
+            TILE_SIZE // 2,
+        )
         pygame.draw.rect(assets["player1"], (0, 0, 0), assets["player1"].get_rect(), 2)
         pygame.draw.rect(assets["player2"], (0, 0, 0), assets["player2"].get_rect(), 2)
         pygame.draw.rect(assets["enemy"], (0, 0, 0), assets["enemy"].get_rect(), 2)
@@ -139,10 +143,14 @@ class BombermanGame(State):
                 self.done = True
                 self.next = "menu"
 
-    def handle_gamepad(self, event: pygame.event.Event) -> None:  # pragma: no cover - placeholder
+    def handle_gamepad(
+        self, event: pygame.event.Event
+    ) -> None:  # pragma: no cover - placeholder
         pass
 
-    def handle_mouse(self, event: pygame.event.Event) -> None:  # pragma: no cover - unused
+    def handle_mouse(
+        self, event: pygame.event.Event
+    ) -> None:  # pragma: no cover - unused
         pass
 
     # ------------------------------------------------------------------ update

--- a/arcade/games/bomberman/bomberman.py
+++ b/arcade/games/bomberman/bomberman.py
@@ -1,0 +1,227 @@
+"""Matrix-themed Bomberman clone scaffolding."""
+from __future__ import annotations
+
+import os
+import random
+import pygame
+
+from state import State
+from utils.persistence import load_json
+from common.theme import PRIMARY_COLOR, draw_text
+from common.ui import PauseMenu
+
+from .level import Level, TILE_SIZE
+from .player import Player, Controls
+from .enemy import Enemy
+from .bomb import Bomb
+from .explosion import Explosion
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config.json")
+SETTINGS_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "settings.json")
+DEFAULT_CONFIG = {
+    "map_size": [15, 13],
+    "enemy_count": 3,
+    "fuse_ms": 2000,
+    "base_blast_radius": 2,
+    "max_bombs_per_player": 1,
+}
+
+
+class BombermanGame(State):
+    fps_cap = 60
+
+    def startup(self, screen, num_players: int = 1, **opts):
+        super().startup(screen, num_players, **opts)
+        self.config = load_json(CONFIG_PATH, DEFAULT_CONFIG)
+        self.settings = load_json(
+            SETTINGS_PATH,
+            {
+                "window_size": [800, 600],
+                "fullscreen": False,
+                "sound_volume": 1.0,
+                "keybindings": {},
+            },
+        )
+        self.assets = self._load_assets()
+        self.level = Level(tuple(self.config.get("map_size", [15, 13])))
+        self.players: list[Player] = []
+        p1_controls = Controls(
+            up=pygame.K_UP,
+            down=pygame.K_DOWN,
+            left=pygame.K_LEFT,
+            right=pygame.K_RIGHT,
+            bomb=pygame.K_SPACE,
+        )
+        self.players.append(
+            Player(1, 1, p1_controls, self.assets["player1"])
+        )
+        if self.num_players == 2:
+            p2_controls = Controls(
+                up=pygame.K_w,
+                down=pygame.K_s,
+                left=pygame.K_a,
+                right=pygame.K_d,
+                bomb=pygame.K_LSHIFT,
+            )
+            self.players.append(
+                Player(
+                    self.level.width - 2,
+                    self.level.height - 2,
+                    p2_controls,
+                    self.assets["player2"],
+                )
+            )
+        self.enemies = self._spawn_enemies()
+        self.bombs: list[Bomb] = []
+        self.explosions: list[Explosion] = []
+        self.pause_menu = PauseMenu(["Resume", "Return to Menu"], font_size=32)
+        self.state = "play"
+        self.game_timer = 0.0
+        self.overlay = pygame.Surface(self.screen.get_size(), pygame.SRCALPHA)
+
+    # ------------------------------------------------------------------ utils
+    def _load_assets(self) -> dict[str, pygame.surface.Surface]:
+        """Generate simple colored surfaces instead of loading images."""
+
+        def surface(color: tuple[int, int, int]) -> pygame.surface.Surface:
+            surf = pygame.Surface((TILE_SIZE, TILE_SIZE), pygame.SRCALPHA)
+            surf.fill(color)
+            return surf
+
+        assets = {
+            "wall": surface((0, 40, 0)),
+            "brick": surface((0, 80, 0)),
+            "player1": surface((0, 200, 0)),
+            "player2": surface((0, 200, 80)),
+            "enemy": surface((200, 0, 0)),
+            "bomb": surface((0, 0, 0)),
+            "blast": surface((200, 200, 0)),
+            "powerup": surface((0, 200, 200)),
+        }
+
+        # add simple details
+        pygame.draw.circle(assets["bomb"], (150, 150, 150), (TILE_SIZE // 2, TILE_SIZE // 2), TILE_SIZE // 2)
+        pygame.draw.rect(assets["player1"], (0, 0, 0), assets["player1"].get_rect(), 2)
+        pygame.draw.rect(assets["player2"], (0, 0, 0), assets["player2"].get_rect(), 2)
+        pygame.draw.rect(assets["enemy"], (0, 0, 0), assets["enemy"].get_rect(), 2)
+
+        return assets
+
+    def _spawn_enemies(self) -> list[Enemy]:
+        enemies: list[Enemy] = []
+        for _ in range(self.config.get("enemy_count", 0)):
+            while True:
+                x = random.randint(1, self.level.width - 2)
+                y = random.randint(1, self.level.height - 2)
+                if self.level.is_blocked(x, y):
+                    continue
+                if (x, y) in [(p.x, p.y) for p in self.players]:
+                    continue
+                enemies.append(Enemy(x, y, self.assets["enemy"]))
+                break
+        return enemies
+
+    # ------------------------------------------------------------------ events
+    def handle_keyboard(self, event: pygame.event.Event) -> None:
+        if self.state == "play":
+            if event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_ESCAPE:
+                    self.state = "pause"
+                    self.pause_menu.index = 0
+                for player in self.players:
+                    if event.key == player.controls.bomb:
+                        player.drop_bomb(self.bombs, self.config.get("fuse_ms", 2000))
+        elif self.state == "pause":
+            choice = self.pause_menu.handle_keyboard(event)
+            if choice == "Resume":
+                self.state = "play"
+            elif choice == "Return to Menu":
+                self.done = True
+                self.next = "menu"
+
+    def handle_gamepad(self, event: pygame.event.Event) -> None:  # pragma: no cover - placeholder
+        pass
+
+    def handle_mouse(self, event: pygame.event.Event) -> None:  # pragma: no cover - unused
+        pass
+
+    # ------------------------------------------------------------------ update
+    def update(self, dt: float) -> None:
+        if self.state != "play":
+            return
+        self.game_timer += dt
+        keys = pygame.key.get_pressed()
+        for player in self.players:
+            player.handle_input(keys, self.level)
+        for enemy in self.enemies:
+            enemy.update(dt, self.level)
+        for bomb in list(self.bombs):
+            if bomb.update(dt):
+                self.explosions.extend(bomb.explode(self.level))
+                self.bombs.remove(bomb)
+        for expl in list(self.explosions):
+            if expl.update(dt):
+                self.explosions.remove(expl)
+
+    # ------------------------------------------------------------------ draw
+    def draw(self) -> None:
+        self.level.draw(self.screen, self.assets)
+        for powerup in []:  # power-ups not yet generated
+            powerup.draw(self.screen)
+        for bomb in self.bombs:
+            bomb.draw(self.screen, self.assets["bomb"])
+        for expl in self.explosions:
+            expl.draw(self.screen, self.assets["blast"])
+        for enemy in self.enemies:
+            enemy.draw(self.screen)
+        for player in self.players:
+            player.draw(self.screen)
+        # HUD
+        mode_text = f"{'1P' if self.num_players == 1 else '2P'} Mode"
+        draw_text(self.screen, mode_text, (10, 10), 24, PRIMARY_COLOR)
+        draw_text(
+            self.screen,
+            f"Enemies: {len(self.enemies)}",
+            (10, 40),
+            24,
+            PRIMARY_COLOR,
+        )
+        if self.num_players == 1:
+            draw_text(
+                self.screen,
+                f"Time: {self.game_timer:0.1f}",
+                (10, 70),
+                24,
+                PRIMARY_COLOR,
+            )
+        if self.state == "pause":
+            self.overlay.fill((0, 0, 0, 200))
+            self.pause_menu.draw(self.overlay)
+            self.screen.blit(self.overlay, (0, 0))
+
+
+def run() -> None:
+    """Run the game directly."""
+    pygame.init()
+    config = load_json(CONFIG_PATH, DEFAULT_CONFIG)
+    width, height = config.get("map_size", [15, 13])
+    screen = pygame.display.set_mode((width * TILE_SIZE, height * TILE_SIZE))
+    game = BombermanGame()
+    game.startup(screen)
+    clock = pygame.time.Clock()
+    running = True
+    while running and not game.done and not game.quit:
+        dt = clock.tick(game.fps_cap) / 1000.0
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+            else:
+                game.get_event(event)
+        game.update(dt)
+        game.draw()
+        pygame.display.flip()
+    pygame.quit()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    run()

--- a/arcade/games/bomberman/config.json
+++ b/arcade/games/bomberman/config.json
@@ -1,0 +1,7 @@
+{
+  "map_size": [15, 13],
+  "enemy_count": 3,
+  "fuse_ms": 2000,
+  "base_blast_radius": 2,
+  "max_bombs_per_player": 1
+}

--- a/arcade/games/bomberman/enemy.py
+++ b/arcade/games/bomberman/enemy.py
@@ -1,4 +1,5 @@
 """Simple enemy AI for Bomberman."""
+
 from __future__ import annotations
 
 import random

--- a/arcade/games/bomberman/enemy.py
+++ b/arcade/games/bomberman/enemy.py
@@ -1,0 +1,30 @@
+"""Simple enemy AI for Bomberman."""
+from __future__ import annotations
+
+import random
+import pygame
+
+from .level import TILE_SIZE, Level
+
+
+class Enemy:
+    def __init__(self, x: int, y: int, image: pygame.surface.Surface):
+        self.x = x
+        self.y = y
+        self.image = image
+        self.move_timer = 0.0
+
+    def update(self, dt: float, level: Level) -> None:
+        self.move_timer -= dt
+        if self.move_timer <= 0:
+            dirs = [(-1, 0), (1, 0), (0, -1), (0, 1)]
+            random.shuffle(dirs)
+            for dx, dy in dirs:
+                nx, ny = self.x + dx, self.y + dy
+                if not level.is_blocked(nx, ny):
+                    self.x, self.y = nx, ny
+                    break
+            self.move_timer = 0.5
+
+    def draw(self, surface: pygame.surface.Surface) -> None:
+        surface.blit(self.image, (self.x * TILE_SIZE, self.y * TILE_SIZE))

--- a/arcade/games/bomberman/explosion.py
+++ b/arcade/games/bomberman/explosion.py
@@ -1,4 +1,5 @@
 """Explosion rendering for Bomberman."""
+
 from __future__ import annotations
 
 import pygame
@@ -16,5 +17,7 @@ class Explosion:
         self.timer -= dt
         return self.timer <= 0
 
-    def draw(self, surface: pygame.surface.Surface, image: pygame.surface.Surface) -> None:
+    def draw(
+        self, surface: pygame.surface.Surface, image: pygame.surface.Surface
+    ) -> None:
         surface.blit(image, (self.x * TILE_SIZE, self.y * TILE_SIZE))

--- a/arcade/games/bomberman/explosion.py
+++ b/arcade/games/bomberman/explosion.py
@@ -1,0 +1,20 @@
+"""Explosion rendering for Bomberman."""
+from __future__ import annotations
+
+import pygame
+
+from .level import TILE_SIZE
+
+
+class Explosion:
+    def __init__(self, x: int, y: int, duration: float = 0.3):
+        self.x = x
+        self.y = y
+        self.timer = duration
+
+    def update(self, dt: float) -> bool:
+        self.timer -= dt
+        return self.timer <= 0
+
+    def draw(self, surface: pygame.surface.Surface, image: pygame.surface.Surface) -> None:
+        surface.blit(image, (self.x * TILE_SIZE, self.y * TILE_SIZE))

--- a/arcade/games/bomberman/game.py
+++ b/arcade/games/bomberman/game.py
@@ -1,4 +1,5 @@
 """Wrapper module for menu auto-discovery."""
+
 from .bomberman import BombermanGame
 
 __all__ = ["BombermanGame"]

--- a/arcade/games/bomberman/game.py
+++ b/arcade/games/bomberman/game.py
@@ -1,0 +1,4 @@
+"""Wrapper module for menu auto-discovery."""
+from .bomberman import BombermanGame
+
+__all__ = ["BombermanGame"]

--- a/arcade/games/bomberman/level.py
+++ b/arcade/games/bomberman/level.py
@@ -1,0 +1,63 @@
+"""Level generation and grid utilities for Bomberman."""
+from __future__ import annotations
+
+import random
+from typing import List
+
+import pygame
+
+TILE_SIZE = 32
+# Tile constants
+EMPTY, WALL, BRICK = 0, 1, 2
+
+
+class Level:
+    """Represents a grid of walls and bricks."""
+
+    def __init__(self, size: tuple[int, int]):
+        self.width, self.height = size
+        self.grid: List[List[int]] = [
+            [EMPTY for _ in range(self.width)] for _ in range(self.height)
+        ]
+        self.generate()
+
+    def generate(self) -> None:
+        """Generate random walls and bricks."""
+        for y in range(self.height):
+            for x in range(self.width):
+                if x == 0 or y == 0 or x == self.width - 1 or y == self.height - 1:
+                    self.grid[y][x] = WALL
+                elif x % 2 == 0 and y % 2 == 0:
+                    self.grid[y][x] = WALL
+                else:
+                    # leave spawn areas empty
+                    if (x, y) in {(1, 1), (1, 2), (2, 1),
+                                  (self.width - 2, self.height - 2),
+                                  (self.width - 3, self.height - 2),
+                                  (self.width - 2, self.height - 3)}:
+                        continue
+                    if random.random() < 0.7:
+                        self.grid[y][x] = BRICK
+
+    def is_blocked(self, x: int, y: int) -> bool:
+        if x < 0 or y < 0 or x >= self.width or y >= self.height:
+            return True
+        return self.grid[y][x] in (WALL, BRICK)
+
+    def destroy(self, x: int, y: int) -> None:
+        if self.grid[y][x] == BRICK:
+            self.grid[y][x] = EMPTY
+
+    def draw(self, surface: pygame.surface.Surface, assets: dict[str, pygame.surface.Surface]) -> None:
+        for y in range(self.height):
+            for x in range(self.width):
+                tile = self.grid[y][x]
+                pos = (x * TILE_SIZE, y * TILE_SIZE)
+                if tile == WALL:
+                    surface.blit(assets["wall"], pos)
+                elif tile == BRICK:
+                    surface.blit(assets["brick"], pos)
+                else:
+                    pygame.draw.rect(surface, (0, 0, 0), (pos[0], pos[1], TILE_SIZE, TILE_SIZE))
+                # grid lines
+                pygame.draw.rect(surface, (0, 40, 0), (pos[0], pos[1], TILE_SIZE, TILE_SIZE), 1)

--- a/arcade/games/bomberman/level.py
+++ b/arcade/games/bomberman/level.py
@@ -1,4 +1,5 @@
 """Level generation and grid utilities for Bomberman."""
+
 from __future__ import annotations
 
 import random
@@ -31,10 +32,14 @@ class Level:
                     self.grid[y][x] = WALL
                 else:
                     # leave spawn areas empty
-                    if (x, y) in {(1, 1), (1, 2), (2, 1),
-                                  (self.width - 2, self.height - 2),
-                                  (self.width - 3, self.height - 2),
-                                  (self.width - 2, self.height - 3)}:
+                    if (x, y) in {
+                        (1, 1),
+                        (1, 2),
+                        (2, 1),
+                        (self.width - 2, self.height - 2),
+                        (self.width - 3, self.height - 2),
+                        (self.width - 2, self.height - 3),
+                    }:
                         continue
                     if random.random() < 0.7:
                         self.grid[y][x] = BRICK
@@ -48,7 +53,9 @@ class Level:
         if self.grid[y][x] == BRICK:
             self.grid[y][x] = EMPTY
 
-    def draw(self, surface: pygame.surface.Surface, assets: dict[str, pygame.surface.Surface]) -> None:
+    def draw(
+        self, surface: pygame.surface.Surface, assets: dict[str, pygame.surface.Surface]
+    ) -> None:
         for y in range(self.height):
             for x in range(self.width):
                 tile = self.grid[y][x]
@@ -58,6 +65,10 @@ class Level:
                 elif tile == BRICK:
                     surface.blit(assets["brick"], pos)
                 else:
-                    pygame.draw.rect(surface, (0, 0, 0), (pos[0], pos[1], TILE_SIZE, TILE_SIZE))
+                    pygame.draw.rect(
+                        surface, (0, 0, 0), (pos[0], pos[1], TILE_SIZE, TILE_SIZE)
+                    )
                 # grid lines
-                pygame.draw.rect(surface, (0, 40, 0), (pos[0], pos[1], TILE_SIZE, TILE_SIZE), 1)
+                pygame.draw.rect(
+                    surface, (0, 40, 0), (pos[0], pos[1], TILE_SIZE, TILE_SIZE), 1
+                )

--- a/arcade/games/bomberman/player.py
+++ b/arcade/games/bomberman/player.py
@@ -1,0 +1,54 @@
+"""Player logic for Bomberman."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import pygame
+
+from .level import TILE_SIZE, Level
+from .bomb import Bomb
+
+
+@dataclass
+class Controls:
+    up: int
+    down: int
+    left: int
+    right: int
+    bomb: int
+
+
+class Player:
+    def __init__(self, x: int, y: int, controls: Controls, image: pygame.surface.Surface):
+        self.x = x
+        self.y = y
+        self.controls = controls
+        self.image = image
+        self.max_bombs = 1
+        self.radius = 2
+
+    @property
+    def rect(self) -> pygame.rect.Rect:
+        return pygame.Rect(self.x * TILE_SIZE, self.y * TILE_SIZE, TILE_SIZE, TILE_SIZE)
+
+    def handle_input(self, keys: pygame.key.ScancodeWrapper, level: Level) -> None:
+        dx = dy = 0
+        if keys[self.controls.left]:
+            dx = -1
+        elif keys[self.controls.right]:
+            dx = 1
+        elif keys[self.controls.up]:
+            dy = -1
+        elif keys[self.controls.down]:
+            dy = 1
+        if dx or dy:
+            nx, ny = self.x + dx, self.y + dy
+            if not level.is_blocked(nx, ny):
+                self.x, self.y = nx, ny
+
+    def drop_bomb(self, bombs: list[Bomb], fuse_ms: int) -> None:
+        if sum(1 for b in bombs if b.owner is self) >= self.max_bombs:
+            return
+        bombs.append(Bomb(self.x, self.y, fuse_ms, self.radius, owner=self))
+
+    def draw(self, surface: pygame.surface.Surface) -> None:
+        surface.blit(self.image, (self.x * TILE_SIZE, self.y * TILE_SIZE))

--- a/arcade/games/bomberman/player.py
+++ b/arcade/games/bomberman/player.py
@@ -1,4 +1,5 @@
 """Player logic for Bomberman."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -18,7 +19,9 @@ class Controls:
 
 
 class Player:
-    def __init__(self, x: int, y: int, controls: Controls, image: pygame.surface.Surface):
+    def __init__(
+        self, x: int, y: int, controls: Controls, image: pygame.surface.Surface
+    ):
         self.x = x
         self.y = y
         self.controls = controls

--- a/arcade/games/bomberman/powerups.py
+++ b/arcade/games/bomberman/powerups.py
@@ -1,0 +1,21 @@
+"""Power-up logic for Bomberman."""
+from __future__ import annotations
+
+import pygame
+
+from .level import TILE_SIZE
+
+
+class PowerUp:
+    def __init__(self, x: int, y: int, kind: str, image: pygame.surface.Surface):
+        self.x = x
+        self.y = y
+        self.kind = kind
+        self.image = image
+
+    def apply(self, player) -> None:
+        if self.kind == "radius":
+            player.radius += 1
+
+    def draw(self, surface: pygame.surface.Surface) -> None:
+        surface.blit(self.image, (self.x * TILE_SIZE, self.y * TILE_SIZE))

--- a/arcade/games/bomberman/powerups.py
+++ b/arcade/games/bomberman/powerups.py
@@ -1,4 +1,5 @@
 """Power-up logic for Bomberman."""
+
 from __future__ import annotations
 
 import pygame


### PR DESCRIPTION
## Summary
- add Matrix-themed Bomberman game skeleton with pause menu
- scaffold level, player, enemy, bomb, explosion and power-up modules
- generate placeholder surfaces in code instead of binary assets

## Testing
- `python - <<'PY'
import os, sys
os.environ['SDL_VIDEODRIVER']='dummy'
sys.path.append('arcade')
import pygame
import main as arcade_main
pygame.init()
games=arcade_main.load_games()
print('bomberman' in games)
game=games['bomberman']
screen=pygame.display.set_mode((640,480))
game.startup(screen)
for _ in range(2):
    game.update(0.016)
    game.draw()
pygame.display.flip()
print('ran')
pygame.quit()
PY`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68982851552083308111d86ac1d586d7