### PR TITLE
Add two-player versus flow to Bomberman

### DIFF
--- a/arcade/arcade_menu.py
+++ b/arcade/arcade_menu.py
@@ -148,7 +148,12 @@ class MainMenuState(State):
                         self.done = True
                     else:
                         self.selected_game = choice
-                        self.phase = "players"
+                        if choice == "bomberman":
+                            self.game_options = {}
+                            self.next = choice
+                            self.done = True
+                        else:
+                            self.phase = "players"
         elif self.phase == "players":
             if event.type == pygame.KEYDOWN:
                 if event.key in (pygame.K_1, pygame.K_KP1):
@@ -191,7 +196,12 @@ class MainMenuState(State):
                         self.done = True
                     else:
                         self.selected_game = choice
-                        self.phase = "players"
+                        if choice == "bomberman":
+                            self.game_options = {}
+                            self.next = choice
+                            self.done = True
+                        else:
+                            self.phase = "players"
                 elif event.button in (1, 9):
                     self.quit = True
             elif event.type in (pygame.JOYAXISMOTION, pygame.JOYHATMOTION):


### PR DESCRIPTION
## Summary
- Add Bomberman mode selector with single or two-player options using shared panel
- Spawn second player and enable victory screen with restart or menu options
- Update main menu to launch Bomberman directly without extra player prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68983bc0a8ec8330aa0aee90672a82a5