### PR TITLE
Add Bomberman docs and resilient asset loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Currently included:
 - Virus – Matrix-themed Dr. Mario-style pill matcher.
 - Kart 8-Bit – retro-inspired split-screen kart racer. WASD or arrow keys to steer,
   Shift/Right Ctrl to boost, Tab to swap splitscreen.
-- Bomberman (Matrix) – drop bombs to clear paths and defeat foes. Arrow keys/WASD to
-  move, Space/Left Shift to plant bombs.
+- [Bomberman (Matrix)](arcade/games/bomberman/README.md) – drop bombs to clear paths
+  and defeat foes. Arrow keys/WASD to move, Space/Left Shift to plant bombs.
 
 Contributions and new mini-games are welcome!

--- a/arcade/games/bomberman/README.md
+++ b/arcade/games/bomberman/README.md
@@ -1,0 +1,25 @@
+# Bomberman (Matrix)
+
+Retro bomberman-inspired mini-game with a green Matrix palette.
+
+## Controls
+
+- Arrow keys / WASD: Move
+- Space / Left Shift: Place bomb
+- Esc: Pause
+- Enter: Confirm menu selection
+
+## Settings
+
+- **Mode**: 1P or 2P
+- **Map Size**: Small, Medium, Large
+- **Enemy Count**: number of AI foes in 1P
+- **Bomb Fuse**: milliseconds before bombs explode
+- **Max Bombs**: bombs each player may carry
+- **Audio**: toggle sounds
+
+## Notes
+
+- Assets load from `assets/` relative to this module. If files are missing,
+  coloured rectangles are generated to preserve the Matrix look.
+- Destroy all enemies to clear a level or outlast your opponent in 2P mode.

--- a/arcade/games/bomberman/level.py
+++ b/arcade/games/bomberman/level.py
@@ -108,19 +108,22 @@ class Level:
     def draw(
         self, surface: pygame.surface.Surface, assets: dict[str, pygame.surface.Surface]
     ) -> None:
+        wall = assets.get("wall")
+        brick = assets.get("brick")
         for y in range(self.height):
             for x in range(self.width):
                 tile = self.grid[y][x]
-                pos = (x * TILE_SIZE, y * TILE_SIZE)
+                rect = (x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE)
                 if tile == WALL:
-                    surface.blit(assets["wall"], pos)
+                    if wall:
+                        surface.blit(wall, rect[:2])
+                    else:
+                        pygame.draw.rect(surface, (0, 40, 0), rect)
                 elif tile == BRICK:
-                    surface.blit(assets["brick"], pos)
+                    if brick:
+                        surface.blit(brick, rect[:2])
+                    else:
+                        pygame.draw.rect(surface, (0, 80, 0), rect)
                 else:
-                    pygame.draw.rect(
-                        surface, (0, 0, 0), (pos[0], pos[1], TILE_SIZE, TILE_SIZE)
-                    )
-                # grid lines
-                pygame.draw.rect(
-                    surface, (0, 40, 0), (pos[0], pos[1], TILE_SIZE, TILE_SIZE), 1
-                )
+                    pygame.draw.rect(surface, (0, 0, 0), rect)
+                pygame.draw.rect(surface, (0, 40, 0), rect, 1)


### PR DESCRIPTION
## Summary
- load Bomberman assets relative to the module with placeholders if files are missing
- draw Bomberman levels with safe fallbacks when textures are absent
- document Bomberman controls and link it from the main README

## Testing
- `ruff check .`
- `black --check arcade/games/bomberman/bomberman.py arcade/games/bomberman/level.py`
- `python -m compileall arcade/games/bomberman`
- `pytest`
- smoke test script for Bomberman 1P/2P with pause/resume and return to menu


------
https://chatgpt.com/codex/tasks/task_e_689859cb509c8330a3b1fdf0636a015e