### PR TITLE
Add save-path utilities and headless game boot tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,22 +5,29 @@ on:
   pull_request:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
-          cache: "pip"
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
-      - name: Lint
-        run: |
-          ruff check .
-          black --check .
-      - name: Run tests
-        run: |
-          pytest -q
+      - name: Ruff
+        run: ruff check .
+      - name: Black
+        run: black --check .
+      - name: Compile sources
+        run: python -m compileall .
+      - name: Pytest
+        env:
+          SDL_VIDEODRIVER: dummy
+        run: pytest
+

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A collection of simple Pygame-based games packaged under an arcade shell.
    bash scripts/run_linux.sh
 
    # Windows
-       scripts\run_windows.bat
+   scripts\run_windows.bat
    ```
 
 ## Updating

--- a/arcade/common/theme.py
+++ b/arcade/common/theme.py
@@ -1,5 +1,7 @@
 import pygame
 
+from ui.layout import scale
+
 # Matrix-style color palette
 BG_COLOR = (0, 0, 0)
 PRIMARY_COLOR = (0, 255, 0)
@@ -7,12 +9,12 @@ ACCENT_COLOR = (0, 155, 0)
 
 
 def get_font(size: int, bold: bool = False) -> pygame.font.Font:
-    """Return a Courier font at the given *size*.
+    """Return a Courier font at the scaled *size*.
 
     All arcade games use the same monospace font to maintain the
     terminal-style aesthetic.
     """
-    return pygame.font.SysFont("Courier", size, bold=bold)
+    return pygame.font.SysFont("Courier", scale(size), bold=bold)
 
 
 def draw_text(

--- a/arcade/common/ui.py
+++ b/arcade/common/ui.py
@@ -1,5 +1,6 @@
 import pygame
 
+from ui.layout import scale
 from .theme import ACCENT_COLOR, PRIMARY_COLOR, draw_text
 
 
@@ -8,7 +9,7 @@ class PauseMenu:
 
     def __init__(self, options: list[str], font_size: int = 32):
         self.options = options
-        self.font_size = font_size
+        self.font_size = scale(font_size)
         self.index = 0
         self.normal_color = ACCENT_COLOR
         self.highlight_color = PRIMARY_COLOR

--- a/arcade/games/bomberman/bomberman.py
+++ b/arcade/games/bomberman/bomberman.py
@@ -8,6 +8,7 @@ import pygame
 
 from state import State
 from utils.persistence import load_json
+from utils.resources import save_path
 from common.theme import ACCENT_COLOR, PRIMARY_COLOR, draw_text, terminal_panel
 from common.ui import PauseMenu
 
@@ -20,7 +21,7 @@ from .powerups import PowerUp
 
 BASE_PATH = Path(__file__).resolve().parent
 CONFIG_PATH = BASE_PATH / "config.json"
-SETTINGS_PATH = BASE_PATH.parents[2] / "settings.json"
+SETTINGS_PATH = save_path("settings.json")
 DEFAULT_CONFIG = {
     "map_size": [15, 13],
     "enemy_count": 3,

--- a/arcade/games/game_collectdots/game.py
+++ b/arcade/games/game_collectdots/game.py
@@ -1,13 +1,14 @@
-import os
 import random
 from datetime import datetime
 import pygame
 from state import State
 from utils.persistence import load_json, save_json
+from utils.resources import save_path
 from common.theme import BG_COLOR, PRIMARY_COLOR, draw_text, get_font
 from common.ui import PauseMenu
 
-SETTINGS_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "settings.json")
+SETTINGS_PATH = save_path("settings.json")
+HS_PATH = save_path("collectdots_highscores.json")
 
 
 class CollectDotsState(State):
@@ -31,7 +32,7 @@ class CollectDotsState(State):
             ["Resume", "Volume -", "Volume +", "Fullscreen", "Quit"],
             font_size=32,
         )
-        self.hs_path = os.path.join(os.path.dirname(__file__), "highscores.json")
+        self.hs_path = HS_PATH
         self.data = load_json(
             self.hs_path, {"highscore": 0, "plays": 0, "last_played": None}
         )

--- a/arcade/games/game_tetroid/game.py
+++ b/arcade/games/game_tetroid/game.py
@@ -1,4 +1,3 @@
-import os
 import random
 import string
 from datetime import datetime
@@ -6,14 +5,15 @@ import pygame
 
 from state import State
 from utils.persistence import load_json, save_json
+from utils.resources import save_path
 
 # Grid size
 GRID_WIDTH = 10
 GRID_HEIGHT = 20
 
 # Path for high scores and settings
-HS_PATH = os.path.join(os.path.dirname(__file__), "highscores.json")
-SETTINGS_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "settings.json")
+HS_PATH = save_path("tetroid_highscores.json")
+SETTINGS_PATH = save_path("settings.json")
 
 # Tetromino definitions: list of rotations, each rotation is list of (x, y)
 TETROMINOES = {

--- a/arcade/games/game_virus/game.py
+++ b/arcade/games/game_virus/game.py
@@ -1,4 +1,3 @@
-import os
 import random
 import string
 from datetime import datetime
@@ -6,14 +5,15 @@ import pygame
 
 from state import State
 from utils.persistence import load_json, save_json
+from utils.resources import save_path
 
 # Grid dimensions for Virus bottle
 GRID_WIDTH = 8
 GRID_HEIGHT = 16
 
 # Paths for high scores and settings
-HS_PATH = os.path.join(os.path.dirname(__file__), "highscores.json")
-SETTINGS_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "settings.json")
+HS_PATH = save_path("virus_highscores.json")
+SETTINGS_PATH = save_path("settings.json")
 
 # Color palette for pills and viruses (RGB values)
 COLORS = [(255, 0, 0), (0, 0, 255), (255, 255, 0)]  # Red  # Blue  # Yellow

--- a/arcade/games/kart8/game.py
+++ b/arcade/games/kart8/game.py
@@ -1,17 +1,16 @@
 import math
-from pathlib import Path
 
 import pygame
 
 from state import State
 from utils.persistence import load_json, save_json
+from utils.resources import save_path
 
 from .engine.track import create_demo_track
 from .engine.renderer import Renderer
 from .engine.physics import Car, Ghost
 
-BASE_PATH = Path(__file__).resolve().parents[2]
-SAVE_PATH = BASE_PATH / "save" / "kart8.json"
+SAVE_PATH = save_path("kart8.json")
 DEFAULT_DATA = {
     "settings": {
         "difficulty": 1.0,
@@ -36,7 +35,7 @@ class KartGame(State):
         if not items:
             self.track.items = []
         self.items_enabled = items
-        self.data = load_json(str(SAVE_PATH), DEFAULT_DATA)
+        self.data = load_json(SAVE_PATH, DEFAULT_DATA)
         settings = self.data.get("settings", {})
         self.difficulty = settings.get("difficulty", 1.0)
         self.layout = settings.get("layout", "vertical")

--- a/arcade/games/wyrm/wyrm.py
+++ b/arcade/games/wyrm/wyrm.py
@@ -1,12 +1,12 @@
-import os
 from typing import List, Set, Tuple
 
 import pygame
 
 from state import State
 from utils.persistence import load_json, save_json
+from utils.resources import asset_path, save_path
 
-SETTINGS_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "settings.json")
+SETTINGS_PATH = save_path("settings.json")
 
 GRID_SIZE = 20
 NUM_SEGMENTS = 12
@@ -69,15 +69,16 @@ class WyrmGame(State):
         self.move_delay = MOVE_DELAY
         self.font = pygame.font.SysFont("Courier", 20)
         self.big_font = pygame.font.SysFont("Courier", 32)
-        base = os.path.join(os.path.dirname(__file__), "assets")
         try:
             self.segment_img = pygame.image.load(
-                os.path.join(base, "segment.png")
+                asset_path("games", "wyrm", "assets", "segment.png")
             ).convert_alpha()
         except Exception:
             self.segment_img = None
         try:
-            self.shot_sound = pygame.mixer.Sound(os.path.join(base, "shot.wav"))
+            self.shot_sound = pygame.mixer.Sound(
+                asset_path("games", "wyrm", "assets", "shot.wav")
+            )
         except Exception:
             self.shot_sound = None
         self.settings = load_json(

--- a/arcade/high_scores.py
+++ b/arcade/high_scores.py
@@ -1,8 +1,8 @@
-import os
 import sqlite3
 from typing import List, Tuple
+from utils.resources import save_path
 
-DB_PATH = os.path.join(os.path.dirname(__file__), "high_scores.db")
+DB_PATH = save_path("high_scores.db")
 
 
 def _get_conn() -> sqlite3.Connection:

--- a/arcade/main.py
+++ b/arcade/main.py
@@ -5,9 +5,11 @@ import pygame
 from arcade_menu import MainMenuState
 from settings_state import SettingsState
 from state import State
+from ui.layout import init as layout_init
 from utils.persistence import load_json, save_json
+from utils.resources import save_path
 
-SETTINGS_PATH = os.path.join(os.path.dirname(__file__), "settings.json")
+SETTINGS_PATH = save_path("settings.json")
 DEFAULT_SETTINGS = {
     "window_size": [800, 600],
     "fullscreen": False,
@@ -59,6 +61,7 @@ def main():
         | (pygame.FULLSCREEN if settings.get("fullscreen") else 0)
     )
     screen = pygame.display.set_mode(base_size, flags, vsync=1)
+    layout_init(screen.get_size())
     pygame.display.set_caption("Arcade")
     pygame.mixer.music.set_volume(settings.get("sound_volume", 1.0))
     clock = pygame.time.Clock()
@@ -86,6 +89,7 @@ def main():
                     | (pygame.FULLSCREEN if settings.get("fullscreen") else 0)
                 )
                 screen = pygame.display.set_mode(base_size, flags, vsync=1)
+                layout_init(screen.get_size())
                 for state in states.values():
                     state.screen = screen
                 save_json(SETTINGS_PATH, settings)
@@ -121,6 +125,7 @@ def main():
                     | (pygame.FULLSCREEN if settings.get("fullscreen") else 0)
                 )
                 screen = pygame.display.set_mode(base_size, flags, vsync=1)
+                layout_init(screen.get_size())
                 for state in states.values():
                     state.screen = screen
             if next_state:

--- a/arcade/settings_state.py
+++ b/arcade/settings_state.py
@@ -1,10 +1,10 @@
-import os
 import pygame
 from state import State
 from utils.persistence import load_json, save_json
+from utils.resources import save_path
 from common.theme import ACCENT_COLOR, BG_COLOR, PRIMARY_COLOR, draw_text
 
-SETTINGS_PATH = os.path.join(os.path.dirname(__file__), "settings.json")
+SETTINGS_PATH = save_path("settings.json")
 DEFAULT_SETTINGS = {
     "window_size": [800, 600],
     "fullscreen": False,

--- a/arcade/ui/__init__.py
+++ b/arcade/ui/__init__.py
@@ -1,0 +1,1 @@
+"""UI helper package."""

--- a/arcade/ui/layout.py
+++ b/arcade/ui/layout.py
@@ -1,0 +1,22 @@
+"""Screen scaling helpers."""
+
+from __future__ import annotations
+
+REFERENCE_RES = (1280, 720)
+_scale = 1.0
+
+
+def init(size: tuple[int, int]) -> None:
+    """Initialise the scaling factor based on *size*."""
+
+    global _scale
+    _scale = min(size[0] / REFERENCE_RES[0], size[1] / REFERENCE_RES[1])
+
+
+def scale(value: int | float) -> int:
+    """Scale *value* relative to the reference resolution."""
+
+    return int(value * _scale)
+
+
+__all__ = ["init", "scale"]

--- a/arcade/utils/resources.py
+++ b/arcade/utils/resources.py
@@ -1,0 +1,44 @@
+"""Helper functions for resolving asset and save file paths."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+# Base directory of the project (the ``arcade`` package root).
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def asset_path(*parts: str) -> Path:
+    """Return an absolute path inside the project for the given *parts*."""
+
+    return PROJECT_ROOT.joinpath(*parts)
+
+
+def _platform_base() -> Path:
+    """Return the OS-specific base directory for persistent data."""
+
+    if sys.platform.startswith("win"):
+        base = Path(os.getenv("APPDATA", Path.home() / "AppData" / "Roaming"))
+    else:
+        base = Path.home() / ".local" / "share"
+    return base / "PythonArcade"
+
+
+def get_save_dir() -> Path:
+    """Ensure and return the directory used for saving user data."""
+
+    path = _platform_base()
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def save_path(*parts: str) -> Path:
+    """Return a path within the persistent save directory."""
+
+    return get_save_dir().joinpath(*parts)
+
+
+__all__ = ["asset_path", "get_save_dir", "save_path"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-pygame>=2.5
+pygame==2.5.2
+typing-extensions>=4.10.0

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -1,0 +1,23 @@
+"""Smoke test ensuring all games initialise without crashing."""
+
+import os
+
+import pygame
+
+from arcade.main import load_games
+from arcade.ui import layout
+
+
+def test_boot_all_games():
+    os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+    os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+    pygame.init()
+    screen = pygame.display.set_mode((640, 480))
+    layout.init(screen.get_size())
+    games = load_games()
+    for state in games.values():
+        state.startup(screen)
+        state.update(0)
+        state.draw()
+    pygame.display.flip()
+    pygame.quit()


### PR DESCRIPTION
## Summary
- centralize asset and save path handling via `utils.resources`
- add resolution-aware UI scaling helpers and integrate with menus
- write `test_boot.py` smoke test for all games
- pin pygame and add CI workflow covering lint, compile, and tests

## Testing
- `python -m compileall .`
- `ruff check --fix .`
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689972b1f9148330a75b92b159869757