### PR TITLE
Implement bomb chain reactions for Bomberman

### DIFF
--- a/arcade/games/bomberman/bomb.py
+++ b/arcade/games/bomberman/bomb.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import List, Optional, Tuple
+
 import pygame
 
 from .level import TILE_SIZE, Level, BRICK
@@ -15,7 +17,7 @@ class Bomb:
         self.timer = fuse_ms / 1000.0
         self.radius = radius
         self.owner = owner
-        self.image: pygame.surface.Surface | None = None
+        self.image: Optional[pygame.surface.Surface] = None
 
     def update(self, dt: float) -> bool:
         self.timer -= dt
@@ -24,8 +26,8 @@ class Bomb:
     def explode(
         self,
         level: Level,
-        bombs: list["Bomb"] | None = None,
-    ) -> tuple[list[Explosion], list[tuple[int, int]]]:
+        bombs: Optional[List["Bomb"]] = None,
+    ) -> Tuple[List[Explosion], List[Tuple[int, int]]]:
         """Create explosion tiles and return destroyed bricks.
 
         Parameters
@@ -41,7 +43,7 @@ class Bomb:
         """
 
         tiles = [(self.x, self.y)]
-        destroyed: list[tuple[int, int]] = []
+        destroyed: List[Tuple[int, int]] = []
         dirs = [(-1, 0), (1, 0), (0, -1), (0, 1)]
         for dx, dy in dirs:
             for i in range(1, self.radius + 1):

--- a/arcade/games/bomberman/bomberman.py
+++ b/arcade/games/bomberman/bomberman.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 import random
+from typing import Optional
+
 import pygame
 
 from state import State
@@ -103,10 +105,10 @@ class BombermanGame(State):
         self.prev_volume = self.settings.get("sound_volume", 1.0)
         self.state = "settings"
         self.winner = 0
-        self.level: Level | None = None
+        self.level: Optional[Level] = None
         self.players: list[Player] = []
-        self.p1: Player | None = None
-        self.p2: Player | None = None
+        self.p1: Optional[Player] = None
+        self.p2: Optional[Player] = None
         self.enemies: list[Enemy] = []
         self.bombs: list[Bomb] = []
         self.explosions: list[Explosion] = []

--- a/arcade/games/bomberman/bomberman.py
+++ b/arcade/games/bomberman/bomberman.py
@@ -408,11 +408,15 @@ class BombermanGame(State):
             if not enemy.update(dt, self.level, self.bombs, self.explosions):
                 self.enemies.remove(enemy)
         for bomb in list(self.bombs):
+            if bomb not in self.bombs:
+                # bomb may have been removed via chain reaction
+                continue
             if bomb.update(dt):
-                explosions, destroyed = bomb.explode(self.level)
+                explosions, destroyed = bomb.explode(self.level, self.bombs)
                 self.explosions.extend(explosions)
                 self._spawn_powerups(destroyed)
-                self.bombs.remove(bomb)
+                if bomb in self.bombs:
+                    self.bombs.remove(bomb)
         for expl in list(self.explosions):
             if expl.update(dt):
                 self.explosions.remove(expl)

--- a/tests/test_bomberman.py
+++ b/tests/test_bomberman.py
@@ -91,4 +91,3 @@ def test_headless_tick_loop(pygame_headless) -> None:
     for _ in range(3):
         game.update(0.1)
     # no assertion; test passes if no exceptions are raised
-

--- a/tests/test_bomberman.py
+++ b/tests/test_bomberman.py
@@ -1,0 +1,94 @@
+"""Core logic tests for the Bomberman mini game.
+
+These tests exercise the bomb explosion logic, including chain reactions and
+tile based damage rules. They run headless using pygame's dummy video driver so
+they can execute in CI environments without a display.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+
+import pygame
+
+# Ensure the project root is importable
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from arcade.games.bomberman.level import Level, EMPTY, WALL, BRICK
+from arcade.games.bomberman.bomb import Bomb
+from arcade.games.bomberman.enemy import Enemy
+
+
+def make_empty_level(w: int = 7, h: int = 5) -> Level:
+    """Return a level with all tiles set to ``EMPTY`` for test control."""
+
+    lvl = Level.generate_random(w, h, seed=1)
+    for y in range(h):
+        for x in range(w):
+            lvl.grid[y][x] = EMPTY
+    return lvl
+
+
+def setup_pygame() -> None:
+    os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+    pygame.init()
+
+
+def teardown_pygame() -> None:
+    pygame.quit()
+
+
+def test_chain_reaction_destroys_soft_block():
+    setup_pygame()
+    lvl = make_empty_level()
+    # place a brick two tiles to the right of the first bomb
+    lvl.grid[2][4] = BRICK
+    b1 = Bomb(1, 2, 1000, 2)
+    b2 = Bomb(3, 2, 1000, 1)
+    bombs = [b1, b2]
+
+    # detonate first bomb; it should trigger the second and destroy the brick
+    b1.explode(lvl, bombs)
+    assert lvl.grid[2][4] == EMPTY
+    assert b2 not in bombs
+    teardown_pygame()
+
+
+def test_hard_block_stops_ray():
+    setup_pygame()
+    lvl = make_empty_level()
+    lvl.grid[1][2] = WALL
+    lvl.grid[1][3] = BRICK
+    bomb = Bomb(1, 1, 1000, 3)
+    bomb.explode(lvl)
+    # brick beyond the wall should remain
+    assert lvl.grid[1][3] == BRICK
+    teardown_pygame()
+
+
+def test_enemy_damage_only_in_ray():
+    setup_pygame()
+    lvl = make_empty_level()
+    bomb = Bomb(1, 1, 1000, 2)
+    explosions, _ = bomb.explode(lvl)
+    e_hit = Enemy(2, 1, pygame.Surface((1, 1)), speed=0.1)
+    e_safe = Enemy(2, 2, pygame.Surface((1, 1)), speed=0.1)
+    assert not e_hit.update(0.1, lvl, [], explosions)
+    assert e_safe.update(0.1, lvl, [], explosions)
+    teardown_pygame()
+
+
+def test_headless_tick_loop():
+    setup_pygame()
+    from arcade.games.bomberman.bomberman import BombermanGame
+
+    screen = pygame.Surface((320, 240))
+    game = BombermanGame()
+    game.startup(screen, num_players=1)
+    for _ in range(3):
+        game.update(0.1)
+    # no assertion; test passes if no exceptions are raised
+    teardown_pygame()
+


### PR DESCRIPTION
## Summary
- enable chained bomb detonations that remove bricks and trigger nearby bombs
- adjust game loop to handle chain reactions safely
- add tests for explosion logic, enemy damage, and headless ticking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899757d42b08330bab5712a750d265f