### PR TITLE
Add codextext TV app installation to Linux script

### DIFF
--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -57,6 +57,36 @@ pygame.display.quit()
 pygame.quit()
 PY
 
+# Install or update the codextext TV app
+TV_DIR="${CODEXTEXT_PATH:-$HOME/.local/share/codextext}"
+if [ -d "$TV_DIR/.git" ]; then
+  git -C "$TV_DIR" pull --ff-only
+else
+  mkdir -p "$(dirname "$TV_DIR")"
+  git clone https://github.com/codextext/tv-app.git "$TV_DIR" || true
+fi
+
+# Wrapper script to launch the TV app
+sudo tee /usr/local/bin/run_tv.sh >/dev/null <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exec "$HOME/.local/share/codextext/run.sh"
+EOF
+sudo chmod +x /usr/local/bin/run_tv.sh
+
+# Desktop entry for graphical launchers
+mkdir -p "$HOME/.local/share/applications"
+cat <<'EOF' > "$HOME/.local/share/applications/tv.desktop"
+[Desktop Entry]
+Type=Application
+Name=TV
+Exec=/usr/local/bin/run_tv.sh
+Icon=video-display
+Terminal=false
+Categories=Video;
+EOF
+update-desktop-database "$HOME/.local/share/applications" || true
+
 cat <<'EOS'
 Installation complete.
 


### PR DESCRIPTION
## Summary
- Clone or update codextext TV app repository
- Install wrapper and desktop entry for TV app

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899aae519b483308570901685be445b