### PR TITLE
docs: fix Bomberman README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Currently included:
 - Virus – Matrix-themed Dr. Mario-style pill matcher.
 - Kart 8-Bit – retro-inspired split-screen kart racer. WASD or arrow keys to steer,
   Shift/Right Ctrl to boost, Tab to swap splitscreen.
-- [Bomberman (Matrix)](arcade/games/bomberman/README.md) – drop bombs to clear paths
+- [Bomberman (Matrix)](pyarcade/games/bomberman/README.md) – drop bombs to clear paths
   and defeat foes. Arrow keys/WASD to move, Space/Left Shift to plant bombs.
 
 Contributions and new mini-games are welcome!


### PR DESCRIPTION
## Summary
- fix broken link to Bomberman game README in top-level docs

## Testing
- `python -m ruff check . --no-fix` *(fails: UP015 etc.)*
- `python -m black --check .`
- `python -m compileall .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689af1cb0d788330b0bd80b1c3bac157