### PR TITLE
Add logging instrumentation and document log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ scripts\update_windows.bat
 - On Linux a graphical environment is required. If you see `pygame.error: No available video device`,
   install SDL libraries or run with `SDL_VIDEODRIVER=dummy`.
 - Updating graphics drivers often fixes window creation or performance issues.
+- Gameplay and menu activity is logged to `arcade.log` in the save directory
+  (`~/.local/share/PythonArcade` on Linux/macOS, `%APPDATA%\PythonArcade` on
+  Windows). Check this file for error details if a game fails to load or crashes.
 
 ## Development & Testing
 

--- a/pyarcade/arcade_menu.py
+++ b/pyarcade/arcade_menu.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import math
 import os
 import random
@@ -148,12 +149,19 @@ class MainMenuState(State):
                     elif choice == "Settings":
                         self.next = choice
                         self.done = True
+                        logging.info("Opening settings menu from main menu")
                     else:
                         self.selected_game = choice
+                        logging.info("Selected game '%s' from main menu", choice)
                         if choice == "bomberman":
                             self.game_options = {}
                             self.next = choice
                             self.done = True
+                            logging.info(
+                                "Starting '%s' with %s player(s)",
+                                choice,
+                                self.num_players,
+                            )
                         else:
                             self.phase = "players"
         elif self.phase == "players":
@@ -173,16 +181,33 @@ class MainMenuState(State):
                     self.game_options = {}
                     self.next = self.selected_game
                     self.done = True
+                    logging.info(
+                        "Starting '%s' with %s player(s)",
+                        self.selected_game,
+                        self.num_players,
+                    )
         elif self.phase == "items":
             if event.type == pygame.KEYDOWN:
                 if event.key in (pygame.K_y, pygame.K_1, pygame.K_KP1):
                     self.game_options = {"items": True}
                     self.next = self.selected_game
                     self.done = True
+                    logging.info(
+                        "Starting '%s' with %s player(s) (items=%s)",
+                        self.selected_game,
+                        self.num_players,
+                        True,
+                    )
                 elif event.key in (pygame.K_n, pygame.K_2, pygame.K_KP2):
                     self.game_options = {"items": False}
                     self.next = self.selected_game
                     self.done = True
+                    logging.info(
+                        "Starting '%s' with %s player(s) (items=%s)",
+                        self.selected_game,
+                        self.num_players,
+                        False,
+                    )
                 elif event.key == pygame.K_ESCAPE:
                     self.phase = "players"
 
@@ -196,12 +221,21 @@ class MainMenuState(State):
                     elif choice == "Settings":
                         self.next = choice
                         self.done = True
+                        logging.info("Opening settings menu from main menu (gamepad)")
                     else:
                         self.selected_game = choice
+                        logging.info(
+                            "Selected game '%s' from main menu (gamepad)", choice
+                        )
                         if choice == "bomberman":
                             self.game_options = {}
                             self.next = choice
                             self.done = True
+                            logging.info(
+                                "Starting '%s' with %s player(s) (gamepad)",
+                                choice,
+                                self.num_players,
+                            )
                         else:
                             self.phase = "players"
                 elif event.button in (1, 9):
@@ -235,16 +269,33 @@ class MainMenuState(State):
                     self.game_options = {}
                     self.next = self.selected_game
                     self.done = True
+                    logging.info(
+                        "Starting '%s' with %s player(s) (gamepad)",
+                        self.selected_game,
+                        self.num_players,
+                    )
         elif self.phase == "items":
             if event.type == pygame.JOYBUTTONDOWN:
                 if event.button == 0:
                     self.game_options = {"items": True}
                     self.next = self.selected_game
                     self.done = True
+                    logging.info(
+                        "Starting '%s' with %s player(s) (items=%s, gamepad)",
+                        self.selected_game,
+                        self.num_players,
+                        True,
+                    )
                 elif event.button == 1:
                     self.game_options = {"items": False}
                     self.next = self.selected_game
                     self.done = True
+                    logging.info(
+                        "Starting '%s' with %s player(s) (items=%s, gamepad)",
+                        self.selected_game,
+                        self.num_players,
+                        False,
+                    )
                 elif event.button in (7, 9):
                     self.phase = "players"
 


### PR DESCRIPTION
## Summary
- configure file-based logging for the arcade launcher, including safer state transitions
- add detailed logging for game loading and menu selections to aid troubleshooting
- document where to find the generated arcade.log file for users

## Testing
- SDL_VIDEODRIVER=dummy pytest

------
https://chatgpt.com/codex/tasks/task_e_68d67d63813883309baec6d7d4e0824a