### PR TITLE
Add username support to online multiplayer lobby

### DIFF
--- a/game-server/public/game.js
+++ b/game-server/public/game.js
@@ -1,0 +1,228 @@
+/* eslint-disable no-undef */
+const socket = io();
+
+const usernameInput = document.getElementById('username-input');
+
+const mainLobbyEls = {
+  view: document.getElementById('main-lobby'),
+  gameSelection: document.getElementById('game-selection'),
+  joinOnlineBtn: document.getElementById('join-online-btn'),
+  roomCodeInput: document.getElementById('room-code-input'),
+};
+
+const matchLobbyEls = {
+  view: document.getElementById('match-lobby'),
+  player1Card: document.getElementById('player-card-1'),
+  player2Card: document.getElementById('player-card-2'),
+  player1Status: document.querySelector('#player-card-1 .player-status'),
+  player2Status: document.querySelector('#player-card-2 .player-status'),
+  readyBtn: document.getElementById('ready-btn'),
+  leaveBtn: document.getElementById('leave-room-btn'),
+};
+
+const gameEls = {
+  view: document.getElementById('game-view'),
+  turnIndicator: document.getElementById('turn-indicator'),
+  gameBoard: document.getElementById('game-board'),
+  gameOverMessage: document.getElementById('game-over-message'),
+  winnerText: document.getElementById('winner-text'),
+  playAgainBtn: document.getElementById('play-again-btn'),
+};
+
+let currentRoomId = null;
+let games = [];
+
+function showView(view) {
+  [mainLobbyEls.view, matchLobbyEls.view, gameEls.view].forEach((section) => {
+    if (!section) return;
+    if (section === view) {
+      section.classList.remove('hidden');
+    } else {
+      section.classList.add('hidden');
+    }
+  });
+}
+
+function getUsername() {
+  const value = usernameInput?.value?.trim();
+  return value && value.length > 0 ? value : null;
+}
+
+function populateGameSelection() {
+  if (!mainLobbyEls.gameSelection) return;
+  mainLobbyEls.gameSelection.innerHTML = '';
+
+  games = [
+    {
+      name: 'Checkers',
+      description: 'Classic Checkers played online.',
+    },
+  ];
+
+  games.forEach((game) => {
+    const card = document.createElement('div');
+    card.className = 'game-card';
+
+    const title = document.createElement('h3');
+    title.textContent = game.name;
+
+    const description = document.createElement('p');
+    description.textContent = game.description;
+
+    const createBtn = document.createElement('button');
+    createBtn.textContent = 'Create Match';
+    createBtn.addEventListener('click', () => {
+      socket.emit('createGame', {
+        gameType: game.name,
+        mode: 'lan',
+        username: getUsername(),
+      });
+    });
+
+    card.appendChild(title);
+    card.appendChild(description);
+    card.appendChild(createBtn);
+    mainLobbyEls.gameSelection.appendChild(card);
+  });
+}
+
+function resetLobbyCards() {
+  const cards = [matchLobbyEls.player1Card, matchLobbyEls.player2Card];
+  cards.forEach((card) => {
+    if (!card) return;
+    card.classList.remove('filled');
+    const name = card.querySelector('.player-name');
+    const status = card.querySelector('.player-status');
+    if (name) name.textContent = 'Waiting for player...';
+    if (status) status.textContent = 'Not Ready';
+  });
+}
+
+function updateMatchLobby(room) {
+  if (!room || !room.players) return;
+
+  resetLobbyCards();
+
+  const playerIds = Object.keys(room.players);
+  if (playerIds.length === 0) return;
+
+  const p1 = room.players[playerIds[0]];
+  if (p1) {
+    matchLobbyEls.player1Card.classList.add('filled');
+    matchLobbyEls.player1Card.querySelector('.player-name').textContent = `${p1.name}${
+      playerIds[0] === room.hostId ? ' (Host)' : ''
+    }`;
+    matchLobbyEls.player1Status.textContent = p1.isReady ? 'Ready' : 'Not Ready';
+  }
+
+  if (playerIds.length > 1) {
+    const p2 = room.players[playerIds[1]];
+    if (p2) {
+      matchLobbyEls.player2Card.classList.add('filled');
+      matchLobbyEls.player2Card.querySelector('.player-name').textContent = `${p2.name}${
+        playerIds[1] === room.hostId ? ' (Host)' : ''
+      }`;
+      matchLobbyEls.player2Status.textContent = p2.isReady ? 'Ready' : 'Not Ready';
+    }
+  }
+}
+
+function joinGame(roomId) {
+  socket.emit('joinGame', {
+    roomId,
+    username: getUsername(),
+  });
+}
+
+// Socket events
+socket.on('connect', () => {
+  populateGameSelection();
+});
+
+socket.on('availableGames', (rooms) => {
+  games = rooms || [];
+  if (!Array.isArray(games)) return;
+  mainLobbyEls.gameSelection.innerHTML = '';
+  games.forEach((room) => {
+    const card = document.createElement('div');
+    card.className = 'game-card';
+
+    const title = document.createElement('h3');
+    title.textContent = `${room.gameType} – ${room.roomId}`;
+
+    const info = document.createElement('p');
+    info.textContent = `${Object.keys(room.players).length}/${room.maxPlayers} players`;
+
+    const joinBtn = document.createElement('button');
+    joinBtn.textContent = 'Join';
+    joinBtn.disabled = Object.keys(room.players).length >= room.maxPlayers;
+    joinBtn.addEventListener('click', () => joinGame(room.roomId));
+
+    card.appendChild(title);
+    card.appendChild(info);
+    card.appendChild(joinBtn);
+    mainLobbyEls.gameSelection.appendChild(card);
+  });
+});
+
+socket.on('roomJoined', (room) => {
+  currentRoomId = room.roomId;
+  updateMatchLobby(room);
+  showView(matchLobbyEls.view);
+});
+
+socket.on('matchLobbyUpdate', (room) => {
+  if (!room || room.roomId !== currentRoomId) return;
+  updateMatchLobby(room);
+});
+
+socket.on('gameStateUpdate', (gameState) => {
+  if (!gameState) return;
+  if (gameState.turn) {
+    gameEls.turnIndicator.textContent = `${gameState.turnName ?? gameState.turn} to move`;
+  }
+
+  if (gameState.gameOver) {
+    const name = gameState.winnerName || gameState.winner || 'Player';
+    gameEls.winnerText.textContent = `${name} Wins!`;
+    gameEls.gameOverMessage.classList.remove('hidden');
+  }
+});
+
+socket.on('error', (message) => {
+  // eslint-disable-next-line no-console
+  console.error('Server error:', message);
+});
+
+// UI events
+mainLobbyEls.joinOnlineBtn?.addEventListener('click', () => {
+  const roomCode = mainLobbyEls.roomCodeInput?.value?.trim();
+  if (!roomCode) return;
+  socket.emit('createGame', {
+    gameType: 'Checkers',
+    mode: 'p2p',
+    roomCode,
+    username: getUsername(),
+  });
+});
+
+matchLobbyEls.readyBtn?.addEventListener('click', () => {
+  if (!currentRoomId) return;
+  socket.emit('toggleReady', { roomId: currentRoomId });
+});
+
+matchLobbyEls.leaveBtn?.addEventListener('click', () => {
+  if (!currentRoomId) return;
+  socket.emit('leaveRoom', { roomId: currentRoomId });
+  currentRoomId = null;
+  showView(mainLobbyEls.view);
+});
+
+gameEls.playAgainBtn?.addEventListener('click', () => {
+  if (!currentRoomId) return;
+  socket.emit('requestRematch', { roomId: currentRoomId });
+  gameEls.gameOverMessage.classList.add('hidden');
+});
+
+// expose joinGame for debugging
+window.joinGame = joinGame;

--- a/game-server/public/index.html
+++ b/game-server/public/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Python Arcade Online Lobby</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main id="app">
+      <section id="main-lobby" class="view">
+        <h1>Python Arcade – Online Lobby</h1>
+        <label for="username-input" class="sr-only">Enter your name</label>
+        <input
+          type="text"
+          id="username-input"
+          placeholder="Enter your name"
+          class="input-field"
+          style="margin-bottom: 1rem; width: 100%;"
+        />
+        <div class="section">
+          <h2>Play Online (P2P)</h2>
+          <div class="actions">
+            <input
+              type="text"
+              id="room-code-input"
+              placeholder="Room code"
+              class="input-field"
+            />
+            <button id="join-online-btn">Join</button>
+          </div>
+        </div>
+        <div class="section">
+          <h2>Local Network Games</h2>
+          <div id="game-selection"></div>
+        </div>
+      </section>
+
+      <section id="match-lobby" class="view hidden">
+        <h2>Match Lobby</h2>
+        <div class="player-card" id="player-card-1">
+          <span class="player-name">Waiting for player...</span>
+          <span class="player-status">Not Ready</span>
+        </div>
+        <div class="player-card" id="player-card-2">
+          <span class="player-name">Waiting for player...</span>
+          <span class="player-status">Not Ready</span>
+        </div>
+        <button id="ready-btn">Ready Up</button>
+        <button id="leave-room-btn">Leave Room</button>
+      </section>
+
+      <section id="game-view" class="view hidden">
+        <h2 id="turn-indicator">Waiting...</h2>
+        <div id="game-board"></div>
+        <div id="game-over-message" class="hidden">
+          <h3 id="winner-text"></h3>
+          <button id="play-again-btn">Play Again</button>
+        </div>
+      </section>
+    </main>
+
+    <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" integrity="sha384-WwBEmp6kAMPx/+qvOB0fOkHn84qxd6Q671O5jM90+hCbGyF/F7fs/3Gzdh0dX8Gk" crossorigin="anonymous"></script>
+    <script src="game.js"></script>
+  </body>
+</html>

--- a/game-server/public/styles.css
+++ b/game-server/public/styles.css
@@ -1,0 +1,62 @@
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  padding: 2rem;
+  background: #0f0f0f;
+  color: #f5f5f5;
+}
+
+.view.hidden {
+  display: none;
+}
+
+.section {
+  margin-top: 1.5rem;
+}
+
+.input-field {
+  padding: 0.6rem 0.8rem;
+  border: 1px solid #444;
+  border-radius: 6px;
+  background: #1d1d1d;
+  color: inherit;
+}
+
+button {
+  padding: 0.6rem 1.2rem;
+  border-radius: 6px;
+  border: none;
+  background: #3a86ff;
+  color: white;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #619bff;
+}
+
+.player-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.75rem 1rem;
+  background: #1a1a1a;
+  border-radius: 8px;
+  margin-bottom: 0.75rem;
+}
+
+.player-card.filled {
+  border: 1px solid #3a86ff;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/game-server/server.js
+++ b/game-server/server.js
@@ -1,0 +1,273 @@
+const path = require('path');
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server, {
+  cors: {
+    origin: '*',
+  },
+});
+
+const STATIC_DIR = path.join(__dirname, 'public');
+
+app.use(express.static(STATIC_DIR));
+
+const players = {};
+const rooms = {};
+
+function normaliseUsername(username) {
+  if (!username) return 'Player';
+  const trimmed = String(username).trim();
+  return trimmed.length > 0 ? trimmed : 'Player';
+}
+
+function initialGameState() {
+  return {
+    players: {},
+    turn: null,
+    turnName: null,
+    gameOver: false,
+    winner: null,
+    winnerName: null,
+  };
+}
+
+function serialiseRoom(room) {
+  return {
+    roomId: room.roomId,
+    hostId: room.hostId,
+    mode: room.mode,
+    gameType: room.gameType,
+    maxPlayers: room.maxPlayers,
+    players: Object.fromEntries(
+      Object.entries(room.players).map(([socketId, player]) => [socketId, { ...player }]),
+    ),
+  };
+}
+
+function computeWinnerName(room) {
+  if (!room.gameState.gameOver || !room.gameState.winner) {
+    room.gameState.winnerName = null;
+    return;
+  }
+
+  const winnerColour = room.gameState.winner;
+  const winnerSocketId = room.gameState.players?.[winnerColour];
+  if (!winnerSocketId) {
+    room.gameState.winnerName = winnerColour;
+    return;
+  }
+
+  const name = players[winnerSocketId]?.username || room.players[winnerSocketId]?.name || 'Player';
+  room.gameState.winnerName = name;
+}
+
+function emitGameState(roomId) {
+  const room = rooms[roomId];
+  if (!room) return;
+  computeWinnerName(room);
+  io.to(roomId).emit('gameStateUpdate', { ...room.gameState });
+}
+
+function broadcastLobby() {
+  const availableRooms = Object.values(rooms).map((room) => serialiseRoom(room));
+  io.emit('availableGames', availableRooms);
+}
+
+function removePlayerFromRoom(socket, roomId) {
+  const room = rooms[roomId];
+  if (!room) return;
+
+  delete room.players[socket.id];
+  if (room.gameState.players) {
+    Object.keys(room.gameState.players).forEach((colour) => {
+      if (room.gameState.players[colour] === socket.id) {
+        room.gameState.players[colour] = null;
+      }
+    });
+  }
+
+  if (room.hostId === socket.id) {
+    const remainingIds = Object.keys(room.players);
+    room.hostId = remainingIds.length > 0 ? remainingIds[0] : null;
+  }
+
+  if (Object.keys(room.players).length === 0) {
+    delete rooms[roomId];
+  } else {
+    io.to(roomId).emit('matchLobbyUpdate', serialiseRoom(room));
+  }
+
+  broadcastLobby();
+}
+
+function joinRoom(socket, roomId) {
+  const room = rooms[roomId];
+  if (!room) return;
+
+  const player = players[socket.id] || { playerId: socket.id, inRoom: null, username: 'Player' };
+  players[socket.id] = player;
+
+  const name = player.username || 'Player';
+  room.players[socket.id] = {
+    playerId: socket.id,
+    name,
+    isReady: false,
+  };
+  player.inRoom = roomId;
+
+  if (!room.hostId) {
+    room.hostId = socket.id;
+  }
+
+  socket.join(roomId);
+
+  socket.emit('roomJoined', serialiseRoom(room));
+  io.to(roomId).emit('matchLobbyUpdate', serialiseRoom(room));
+  broadcastLobby();
+}
+
+function startGame(roomId) {
+  const room = rooms[roomId];
+  if (!room) return;
+
+  const playerIds = Object.keys(room.players);
+  if (playerIds.length < 2) return;
+
+  const [redPlayer, blackPlayer] = playerIds;
+
+  room.gameState.players = {
+    red: redPlayer,
+    black: blackPlayer,
+  };
+  room.gameState.turn = 'red';
+  room.gameState.turnName = room.players[redPlayer]?.name || 'Red';
+  room.gameState.gameOver = false;
+  room.gameState.winner = null;
+  room.gameState.winnerName = null;
+
+  io.to(roomId).emit('gameStateUpdate', { ...room.gameState });
+}
+
+io.on('connection', (socket) => {
+  players[socket.id] = { playerId: socket.id, inRoom: null, username: 'Player' };
+  broadcastLobby();
+
+  socket.on('createGame', ({ gameType, mode, roomCode, username }) => {
+    const player = players[socket.id] || { playerId: socket.id };
+    player.username = normaliseUsername(username);
+    player.inRoom = null;
+    players[socket.id] = player;
+
+    const roomId = mode === 'p2p' && roomCode ? roomCode : `room_${Math.random().toString(36).slice(2, 7)}`;
+
+    rooms[roomId] = {
+      roomId,
+      hostId: socket.id,
+      mode: mode || 'lan',
+      gameType: gameType || 'Checkers',
+      maxPlayers: 2,
+      players: {},
+      gameState: initialGameState(),
+    };
+
+    joinRoom(socket, roomId);
+  });
+
+  socket.on('joinGame', ({ roomId, username }) => {
+    const room = rooms[roomId];
+    if (!room) {
+      socket.emit('error', 'Room is full or does not exist.');
+      return;
+    }
+    if (Object.keys(room.players).length >= room.maxPlayers) {
+      socket.emit('error', 'Room is full or does not exist.');
+      return;
+    }
+
+    const player = players[socket.id] || { playerId: socket.id };
+    player.username = normaliseUsername(username);
+    player.inRoom = roomId;
+    players[socket.id] = player;
+
+    joinRoom(socket, roomId);
+  });
+
+  socket.on('toggleReady', ({ roomId }) => {
+    const room = rooms[roomId];
+    if (!room) return;
+    const player = room.players[socket.id];
+    if (!player) return;
+
+    player.isReady = !player.isReady;
+    io.to(roomId).emit('matchLobbyUpdate', serialiseRoom(room));
+
+    const allReady =
+      Object.keys(room.players).length === room.maxPlayers &&
+      Object.values(room.players).every((p) => p.isReady);
+
+    if (allReady) {
+      startGame(roomId);
+    }
+  });
+
+  socket.on('leaveRoom', ({ roomId }) => {
+    const player = players[socket.id];
+    if (player) {
+      player.inRoom = null;
+    }
+    removePlayerFromRoom(socket, roomId);
+    socket.leave(roomId);
+  });
+
+  socket.on('requestRematch', ({ roomId }) => {
+    const room = rooms[roomId];
+    if (!room) return;
+
+    Object.values(room.players).forEach((p) => {
+      p.isReady = false;
+    });
+    room.gameState = initialGameState();
+
+    io.to(roomId).emit('matchLobbyUpdate', serialiseRoom(room));
+    emitGameState(roomId);
+  });
+
+  socket.on('reportWinner', ({ roomId, winner }) => {
+    const room = rooms[roomId];
+    if (!room) return;
+    if (!winner || !['red', 'black'].includes(winner)) return;
+
+    room.gameState.gameOver = true;
+    room.gameState.winner = winner;
+    computeWinnerName(room);
+    emitGameState(roomId);
+  });
+
+  socket.on('disconnect', () => {
+    const player = players[socket.id];
+    if (!player) return;
+
+    const { inRoom } = player;
+    if (inRoom) {
+      removePlayerFromRoom(socket, inRoom);
+    }
+
+    delete players[socket.id];
+    broadcastLobby();
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+
+if (require.main === module) {
+  server.listen(PORT, () => {
+    // eslint-disable-next-line no-console
+    console.log(`Server listening on port ${PORT}`);
+  });
+}
+
+module.exports = { app, server, io, players, rooms };


### PR DESCRIPTION
## Summary
- add a username field to the online lobby so players can enter display names
- send the chosen username in all create/join flows and surface player names throughout the lobby and game state
- persist usernames on the server for rooms and winner announcements, defaulting to a generic label when blank

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6b8971a18833093228b290e4f0e6f